### PR TITLE
#60 displayname added to JWT

### DIFF
--- a/service/src/main/resources/example.application.yaml
+++ b/service/src/main/resources/example.application.yaml
@@ -31,6 +31,7 @@ loginsvc:
               groups: []
             - username: "TestUser"
               password: "password123"
+              displayname: "Test User, A.C.E."
               email: "test@abs.com"
               groups:
                 - "groupA"

--- a/service/src/main/scala/za/co/absa/loginsvc/rest/config/auth/UsersConfig.scala
+++ b/service/src/main/scala/za/co/absa/loginsvc/rest/config/auth/UsersConfig.scala
@@ -59,11 +59,12 @@ case class UsersConfig(knownUsers: Array[UserConfig], order: Int)
 case class UserConfig(username: String,
                        password: String,
                        email: Option[String],
+                       displayname: Option[String],
                        groups: Array[String]
                      ) extends ConfigValidatable {
 
   override def toString: String = {
-    s"UserConfig($username, $password, ${email.getOrElse("")}, ${Option(groups).map(_.toList)})"
+    s"UserConfig($username, $password, ${email.getOrElse("")}, ${displayname.getOrElse("")}, ${Option(groups).map(_.toList)})"
   }
 
   override def validate(): ConfigValidationResult = {

--- a/service/src/main/scala/za/co/absa/loginsvc/rest/provider/ConfigUsersAuthenticationProvider.scala
+++ b/service/src/main/scala/za/co/absa/loginsvc/rest/provider/ConfigUsersAuthenticationProvider.scala
@@ -39,7 +39,7 @@ class ConfigUsersAuthenticationProvider(usersConfig: UsersConfig) extends Authen
     usersConfig.knownUsersMap.get(username).map { usersConfig =>
       if (usersConfig.password == password) {
         logger.info(s"user login: $username - ok")
-        val principal = User(username, usersConfig.email, usersConfig.groups.toList)
+        val principal = User(username, usersConfig.email, usersConfig.displayname, usersConfig.groups.toList)
         new UsernamePasswordAuthenticationToken(principal, password,
           usersConfig.groups.map(new SimpleGrantedAuthority(_)).toList.asJava)
       } else {

--- a/service/src/main/scala/za/co/absa/loginsvc/rest/service/JWTService.scala
+++ b/service/src/main/scala/za/co/absa/loginsvc/rest/service/JWTService.scala
@@ -53,8 +53,8 @@ class JWTService @Autowired()(jwtConfigProvider: JwtConfigProvider) {
       .setExpiration(expiration)
       .setIssuedAt(issuedAt)
       .claim("groups", groupsClaim)
-      .applyOrBypass(user.email, (builder, value: String) => builder.claim("email", value))
-      .applyOrBypass(user.displayName, (builder, value: String) => builder.claim("displayname", value))
+      .applyIfDefined(user.email, (builder, value: String) => builder.claim("email", value))
+      .applyIfDefined(user.displayName, (builder, value: String) => builder.claim("displayname", value))
       .signWith(rsaKeyPair.getPrivate)
       .compact()
   }
@@ -65,8 +65,8 @@ class JWTService @Autowired()(jwtConfigProvider: JwtConfigProvider) {
 
 object JWTService {
   implicit class JwtBuilderExt(val jwtBuilder: JwtBuilder) extends AnyVal {
-    def applyOrBypass[T](opt: Option[T], fn: (JwtBuilder, T) => JwtBuilder): JwtBuilder = {
-      OptionExt.applyOrBypass(jwtBuilder, opt, fn)
+    def applyIfDefined[T](opt: Option[T], fn: (JwtBuilder, T) => JwtBuilder): JwtBuilder = {
+      OptionExt.applyIfDefined(jwtBuilder, opt, fn)
     }
   }
 }

--- a/service/src/main/scala/za/co/absa/loginsvc/utils/OptionExt.scala
+++ b/service/src/main/scala/za/co/absa/loginsvc/utils/OptionExt.scala
@@ -14,6 +14,25 @@
  * limitations under the License.
  */
 
-package za.co.absa.loginsvc.model
+package za.co.absa.loginsvc.utils
 
-case class User(name: String, email: Option[String], displayName: Option[String], groups: Seq[String])
+object OptionExt {
+
+  /**
+   * For `target`, either return as is (if `optValueToApply` is None) or apply fn `func`
+   * @param target
+   * @param optValueToApply
+   * @param func
+   * @tparam A
+   * @tparam B
+   * @return
+   */
+  def applyOrBypass[A, B](target: A, optValueToApply: Option[B], func: (A, B) => A): A = {
+    optValueToApply.map { valueToApply =>
+      func(target, valueToApply)
+    }.getOrElse {
+      target
+    }
+  }
+
+}

--- a/service/src/main/scala/za/co/absa/loginsvc/utils/OptionExt.scala
+++ b/service/src/main/scala/za/co/absa/loginsvc/utils/OptionExt.scala
@@ -27,7 +27,7 @@ object OptionExt {
    * @tparam B
    * @return
    */
-  def applyOrBypass[A, B](target: A, optValueToApply: Option[B], func: (A, B) => A): A = {
+  def applyIfDefined[A, B](target: A, optValueToApply: Option[B], func: (A, B) => A): A = {
     optValueToApply.map { valueToApply =>
       func(target, valueToApply)
     }.getOrElse {

--- a/service/src/test/resources/application.yaml
+++ b/service/src/test/resources/application.yaml
@@ -23,6 +23,12 @@ loginsvc:
               password: "password1"
               groups:
                 - "group1"
+            - username: "user2"
+              password: "password2"
+              displayname: "User Two"
+              email: "user@two.org"
+              groups:
+                - "group2"
 
 # App Config
 spring:

--- a/service/src/test/scala/za/co/absa/loginsvc/rest/FakeAuthentication.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/rest/FakeAuthentication.scala
@@ -26,7 +26,7 @@ import java.util
 
 object FakeAuthentication {
 
-  val fakeUser: User = User("fakeUser", Some("fake@gmail.com"), Seq.empty)
+  val fakeUser: User = User("fakeUser", Some("fake@gmail.com"), Some("Fake Name"), Seq.empty)
 
   val fakeUserAuthentication: Authentication = new UsernamePasswordAuthenticationToken(
     fakeUser, "fakePassword", new util.ArrayList[GrantedAuthority]()

--- a/service/src/test/scala/za/co/absa/loginsvc/rest/config/auth/UsersConfigTest.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/rest/config/auth/UsersConfigTest.scala
@@ -23,7 +23,7 @@ import za.co.absa.loginsvc.rest.config.validation.ConfigValidationResult.{Config
 
 class UsersConfigTest extends AnyFlatSpec with Matchers {
 
-  private val userCfg = UserConfig("user1", "password1", Option("mail@here.tld"), Array("group1", "group2"))
+  private val userCfg = UserConfig("user1", "password1", Option("mail@here.tld"), Option("Fake Name"), Array("group1", "group2"))
 
   "UserConfig" should "validate expected filled content" in {
     userCfg.validate() shouldBe ConfigValidationSuccess
@@ -67,13 +67,13 @@ class UsersConfigTest extends AnyFlatSpec with Matchers {
 
   it should "fail on duplicate knownUsers" in {
     val duplicateValidationResult = UsersConfig(knownUsers = Array(
-      UserConfig("sameUser", "password1", Option("mail@here.tld"), Array("group1", "group2")),
-      UserConfig("sameUser", "password2", Option("anotherMail@here.tld"), Array()),
+      UserConfig("sameUser", "password1", Option("mail@here.tld"), Option("Fake1"), Array("group1", "group2")),
+      UserConfig("sameUser", "password2", Option("anotherMail@here.tld"), Option("Fake2"), Array()),
 
-      UserConfig("sameUser2", "passwordX", Option("abc@def"), Array()),
-      UserConfig("sameUser2", "passwordA", Option(null), Array()),
+      UserConfig("sameUser2", "passwordX", Option("abc@def"), Option("Fake1"), Array()),
+      UserConfig("sameUser2", "passwordA", Option(null), Option(null), Array()),
 
-      UserConfig("okUser", "passwordO", Option("ooo@"), Array())
+      UserConfig("okUser", "passwordO", Option("ooo@"),  Option("Fake1"), Array())
     ), 1).validate()
 
     duplicateValidationResult shouldBe a[ConfigValidationError]
@@ -86,12 +86,12 @@ class UsersConfigTest extends AnyFlatSpec with Matchers {
 
   it should "fail multiple errors" in {
     val multiErrorsResult = UsersConfig(knownUsers = Array(
-      UserConfig("sameUser", "password1", Option("mail@here.tld"), Array("group1", "group2")),
-      UserConfig("sameUser", "password2", Option("anotherMail@here.tld"), Array()),
+      UserConfig("sameUser", "password1", Option("mail@here.tld"), Option("Fake1"), Array("group1", "group2")),
+      UserConfig("sameUser", "password2", Option("anotherMail@here.tld"), Option("Fake2"), Array()),
 
-      UserConfig("userNoPass", null, Option("abc@def"), Array()),
-      UserConfig("noMailIsFine", "password2", Option(null), Array()),
-      UserConfig("userNoMissingGroups", "passwordO", Option("ooo@"), null)
+      UserConfig("userNoPass", null, Option("abc@def"), Option("FakeName"), Array()),
+      UserConfig("noMailIsFine", "password2", Option(null), Option(null), Array()),
+      UserConfig("userNoMissingGroups", "passwordO", Option("ooo@"),  Option("Fake2"), null)
     ), 1).validate()
 
     multiErrorsResult shouldBe a[ConfigValidationError]

--- a/service/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
@@ -44,12 +44,20 @@ class ConfigProviderTest extends AnyFlatSpec with Matchers  {
       activeDirectoryLDAPConfig.order  == 1)
   }
 
-  "The usersConfig properties" should "Match" in {
+  "The usersConfig properties" should "be loaded correctly" in {
     val usersConfig: UsersConfig = configProvider.getUsersConfig
+    assert(usersConfig.order == 0)
+
     assert(usersConfig.knownUsers(0).groups(0) == "group1" &&
       usersConfig.knownUsers(0).email.isEmpty &&
+      usersConfig.knownUsers(0).displayname.isEmpty &&
       usersConfig.knownUsers(0).password == "password1" &&
-      usersConfig.knownUsers(0).username == "user1" &&
-      usersConfig.order == 0)
+      usersConfig.knownUsers(0).username == "user1")
+
+    assert(usersConfig.knownUsers(1).groups(0) == "group2" &&
+      usersConfig.knownUsers(1).email == Some("user@two.org") &&
+      usersConfig.knownUsers(1).displayname == Some("User Two") &&
+      usersConfig.knownUsers(1).password == "password2" &&
+      usersConfig.knownUsers(1).username == "user2")
   }
 }

--- a/service/src/test/scala/za/co/absa/loginsvc/rest/provider/ConfigUsersAuthenticationProviderTest.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/rest/provider/ConfigUsersAuthenticationProviderTest.scala
@@ -27,7 +27,7 @@ class ConfigUsersAuthenticationProviderTest extends AnyFlatSpec with Matchers {
 
   // testing config we are running against
   val testConfig: UsersConfig = UsersConfig(Array(
-    UserConfig("testuser", "testpassword", Option("testuser@example.com"), Array())
+    UserConfig("testuser", "testpassword", Option("testuser@example.com"), Option("Test User"), Array())
   ), 1)
   val authProvider = new ConfigUsersAuthenticationProvider(testConfig)
 

--- a/service/src/test/scala/za/co/absa/loginsvc/rest/service/JWTServiceTest.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/rest/service/JWTServiceTest.scala
@@ -32,6 +32,7 @@ class JWTServiceTest extends AnyFlatSpec {
   private val userWithoutEmailAndGroups: User = User(
     name = "testUser",
     email = None,
+    displayName = None,
     groups = Seq.empty
   )
 

--- a/service/src/test/scala/za/co/absa/loginsvc/utils/OptionExtTest.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/utils/OptionExtTest.scala
@@ -20,12 +20,12 @@ import org.scalatest.matchers.should.Matchers
 
 class OptionExtTest extends AnyFlatSpec with Matchers {
 
-  "OptionExt.applyOrBypass" should "apply fn correctly if defined" in {
-    OptionExt.applyOrBypass(1, Some(2), (a:Int, b: Int) => a + b) shouldBe 3
+  "OptionExt.applyIfDefined" should "apply fn correctly if defined" in {
+    OptionExt.applyIfDefined(1, Some(2), (a:Int, b: Int) => a + b) shouldBe 3
   }
 
-  "OptionExt.applyOrBypass" should "not apply fn if empty" in {
-    OptionExt.applyOrBypass(1, None, (a: Int, b: Int) => a + b) shouldBe 1
+  "OptionExt.applyIfDefined" should "not apply fn if empty" in {
+    OptionExt.applyIfDefined(1, None, (a: Int, b: Int) => a + b) shouldBe 1
   }
 
 }

--- a/service/src/test/scala/za/co/absa/loginsvc/utils/OptionExtTest.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/utils/OptionExtTest.scala
@@ -13,7 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package za.co.absa.loginsvc.utils
 
-package za.co.absa.loginsvc.model
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-case class User(name: String, email: Option[String], displayName: Option[String], groups: Seq[String])
+class OptionExtTest extends AnyFlatSpec with Matchers {
+
+  "OptionExt.applyOrBypass" should "apply fn correctly if defined" in {
+    OptionExt.applyOrBypass(1, Some(2), (a:Int, b: Int) => a + b) shouldBe 3
+  }
+
+  "OptionExt.applyOrBypass" should "not apply fn if empty" in {
+    OptionExt.applyOrBypass(1, None, (a: Int, b: Int) => a + b) shouldBe 1
+  }
+
+}


### PR DESCRIPTION
The user token now optionally contains field `displayname` for a friendly name string. This either comes from LDAP's `displayname` field or from user config (also `displayname` field).

Some unit tests added/adjusted.

FYI @fateeand 

## Example - config-based:
With config of
```yaml
            - username: "TestUser"
              password: "password123"
              displayname: "Test User MD"
              email: "test@abs.com"
              groups:
                - "groupA"
                - "groupB"
```
the token contains this information:
```json
{
  "sub": "TestUser",
  "exp": 1692365356,
  "iat": 1692350956,
  "groups": [
    "groupA",
    "groupB"
  ],
  "email": "test@abs.com",
  "displayname": "Test User MD"
}
```

## Example - LDAP-based:
.. tested against company LDAP

```json
{
  ...,
  "displayname": "Daniel Kavan (CZ)"
}

