### PR TITLE
JWKS demo

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,8 @@ object Dependencies {
 
     val jjwt = "0.11.5"
 
+    val nimbusJoseJwt = "9.31"
+
     val scalatest = "3.2.15"
 
     val pureConfig = "0.17.2"
@@ -46,6 +48,8 @@ object Dependencies {
   lazy val jjwtApi = "io.jsonwebtoken" % "jjwt-api" % Versions.jjwt
   lazy val jjwtImpl = "io.jsonwebtoken" % "jjwt-impl" % Versions.jjwt % Runtime
   lazy val jjwtJackson = "io.jsonwebtoken" % "jjwt-jackson" % Versions.jjwt % Runtime
+
+  lazy val nimbusJoseJwt = "com.nimbusds" % "nimbus-jose-jwt" % Versions.nimbusJoseJwt
 
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig" % Versions.pureConfig
   lazy val pureConfigYaml = "com.github.pureconfig" %% "pureconfig-yaml" % Versions.pureConfig
@@ -77,6 +81,8 @@ object Dependencies {
     jjwtApi,
     jjwtImpl,
     jjwtJackson,
+
+    nimbusJoseJwt,
 
     pureConfig,
     pureConfigYaml,

--- a/service/src/main/scala/za/co/absa/loginsvc/rest/SecurityConfig.scala
+++ b/service/src/main/scala/za/co/absa/loginsvc/rest/SecurityConfig.scala
@@ -39,6 +39,7 @@ class SecurityConfig {
         "/swagger-ui/**", "/swagger-ui.html", // "/swagger-ui.html" redirects to "/swagger-ui/index.html
         "/swagger-resources/**", "/v3/api-docs/**", // swagger needs these
         "/actuator/**",
+        "/token/public-key-jwks",
         "/token/public-key").permitAll()
         .anyRequest().authenticated()
         .and()

--- a/service/src/main/scala/za/co/absa/loginsvc/rest/controller/TokenController.scala
+++ b/service/src/main/scala/za/co/absa/loginsvc/rest/controller/TokenController.scala
@@ -107,4 +107,22 @@ class TokenController @Autowired()(jwtService: JWTService) {
     Future.successful(PublicKeyWrapper(publicKeyBase64))
   }
 
+  @Tags(Array(new Tag(name = "token")))
+  @Operation(
+    summary = "Gives payload with the RSA256 public key in JWKS format",
+    description = "Returns the same information as /token/public-key, but as a JSON Web Key Set",
+    responses = Array(
+    new ApiResponse(responseCode = "200", description = "Success", content = Array(new Content(examples = Array(new ExampleObject(value = """{"keys":[{"kty": "EC","crv": "P-256","x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","use": "enc","kid": "1"},{"kty": "RSA","n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e": "AQAB","alg": "RS256","kid": "2011-04-29"}]}"""))))),
+  ))
+  @GetMapping(
+    path = Array("/public-key-jwks"),
+    produces = Array(MediaType.APPLICATION_JSON_VALUE)
+  )
+  @ResponseStatus(HttpStatus.OK)
+  def getPublicKeyJwks(): CompletableFuture[Map[String, AnyRef]] = {
+    val jwks = jwtService.jwks
+
+    import scala.collection.JavaConverters._
+    Future.successful(jwks.toJSONObject(true).asScala.toMap)
+  }
 }

--- a/service/src/main/scala/za/co/absa/loginsvc/rest/service/JWTService.scala
+++ b/service/src/main/scala/za/co/absa/loginsvc/rest/service/JWTService.scala
@@ -38,7 +38,6 @@ class JWTService @Autowired()(jwtConfigProvider: JwtConfigProvider) {
 
   private val jwtConfig = jwtConfigProvider.getJWTConfig
   private val rsaKeyPair: KeyPair = Keys.keyPairFor(SignatureAlgorithm.valueOf(jwtConfig.algName))
-  private val kid: String = publicKeyThumbprint
 
   def generateToken(user: User): String = {
     import scala.collection.JavaConverters._
@@ -56,7 +55,7 @@ class JWTService @Autowired()(jwtConfigProvider: JwtConfigProvider) {
       .setSubject(user.name)
       .setExpiration(expiration)
       .setIssuedAt(issuedAt)
-      .claim("kid", kid)
+      .claim("kid", publicKeyThumbprint)
       .claim("groups", groupsClaim)
       .applyIfDefined(user.email, (builder, value: String) => builder.claim("email", value))
       .applyIfDefined(user.displayName, (builder, value: String) => builder.claim("displayname", value))
@@ -71,13 +70,13 @@ class JWTService @Autowired()(jwtConfigProvider: JwtConfigProvider) {
       case rsaKey: RSAPublicKey => new RSAKey.Builder(rsaKey)
         .keyUse(KeyUse.SIGNATURE)
         .algorithm(JWSAlgorithm.parse(jwtConfig.algName))
-        .keyID(kid)
+        .keyIDFromThumbprint()
         .build()
       case _ => throw new IllegalArgumentException("Unsupported public key type")
     }
   }
 
-  def publicKeyThumbprint: String = rsaPublicKey.computeThumbprint().toString
+  def publicKeyThumbprint: String = rsaPublicKey.getKeyID
 
   def jwks: JWKSet = {
     val jwk = rsaPublicKey

--- a/service/src/test/scala/za/co/absa/loginsvc/rest/service/JWTServiceTest.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/rest/service/JWTServiceTest.scala
@@ -16,6 +16,8 @@
 
 package za.co.absa.loginsvc.rest.service
 
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.KeyUse
 import io.jsonwebtoken.{Claims, Jws, Jwts}
 import org.scalatest.flatspec.AnyFlatSpec
 import za.co.absa.loginsvc.model.User
@@ -115,4 +117,23 @@ class JWTServiceTest extends AnyFlatSpec {
     assert(actualGroups === userWithGroups.groups)
   }
 
+  behavior of "jwks"
+
+  it should "return a JWK that is equivalent to the `publicKey`" in {
+    import scala.collection.JavaConverters._
+
+    val publicKey = jwtService.publicKey
+    val jwks = jwtService.jwks
+    val rsaKey = jwks.getKeys.asScala.head.toRSAKey
+
+    assert(publicKey == rsaKey.toPublicKey)
+  }
+
+  it should "return a JWK with parameters" in {
+    import scala.collection.JavaConverters._
+
+    val jwk = jwtService.jwks.getKeys.asScala.head
+    assert(jwk.getAlgorithm == JWSAlgorithm.RS256)
+    assert(jwk.getKeyUse == KeyUse.SIGNATURE)
+  }
 }

--- a/service/src/test/scala/za/co/absa/loginsvc/rest/service/JWTServiceTest.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/rest/service/JWTServiceTest.scala
@@ -91,6 +91,17 @@ class JWTServiceTest extends AnyFlatSpec {
     }
   }
 
+  it should "return a JWT kid" in {
+    val jwt = jwtService.generateToken(userWithoutEmailAndGroups)
+    val parsedJWT = parseJWT(jwt)
+
+    assert(parsedJWT.isSuccess)
+    parsedJWT.foreach { jwt =>
+      val kid = jwt.getBody.get("kid")
+      assert(kid === jwtService.publicKeyThumbprint)
+    }
+  }
+
   it should "turn groups into empty `groups` claim for user without groups" in {
     import scala.collection.JavaConverters._
 

--- a/service/src/test/scala/za/co/absa/loginsvc/rest/service/JWTServiceTest.scala
+++ b/service/src/test/scala/za/co/absa/loginsvc/rest/service/JWTServiceTest.scala
@@ -132,7 +132,10 @@ class JWTServiceTest extends AnyFlatSpec {
   it should "return a JWK with parameters" in {
     import scala.collection.JavaConverters._
 
-    val jwk = jwtService.jwks.getKeys.asScala.head
+    val keys = jwtService.jwks.getKeys.asScala
+    assert(keys.length == 1, "One JWK is expected to be generated now")
+
+    val jwk = keys.head
     assert(jwk.getAlgorithm == JWSAlgorithm.RS256)
     assert(jwk.getKeyUse == KeyUse.SIGNATURE)
   }


### PR DESCRIPTION
Closes #62 

This is just a draft to demonstrate the JWKS endpoint for the public key. JWKS is a standard defined in https://datatracker.ietf.org/doc/html/rfc7517 and is implemented e.g. by 
`org.springframework.boot:spring-boot-starter-oauth2-resource-server`. Resource servers can just add this dependency instead of implementing fetching and parsing the endpoint themselves. Instead, it's just one line of application configuration, i.e.

`spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:9090/token/public-key-jwks`

and a few lines in the security configuration (which you need for any JWT security)

## Problems
The following issues need to be discussed before merging
- I had to add the Nimbus JOSE JWT library https://bitbucket.org/connect2id/nimbus-jose-jwt/src/master/, https://connect2id.com/products/nimbus-jose-jwt, which covers similar functionality as https://github.com/jwtk/jjwt. Unfortunately, jjwt supports JWK only in master, but not in the latest released version v0.11.5