### PR TITLE
Use / as server url

### DIFF
--- a/service/src/main/scala/za/co/absa/loginsvc/rest/Application.scala
+++ b/service/src/main/scala/za/co/absa/loginsvc/rest/Application.scala
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
 import io.swagger.v3.oas.annotations.info.{Info, License}
 import io.swagger.v3.oas.annotations.security.SecurityScheme
 import io.swagger.v3.oas.annotations.{ExternalDocumentation, OpenAPIDefinition}
+import io.swagger.v3.oas.annotations.servers.Server
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.builder.SpringApplicationBuilder
@@ -38,7 +39,8 @@ import org.springframework.context.annotation._
     title = "Login Service API",
     version = "0.1", // TODO load from config/package -- possibly part of Issue #5
     license = new License(name = "Apache 2.0", url = "https://www.apache.org/licenses/LICENSE-2.0.html")
-  )
+  ),
+  servers = Array(new Server(url = "/"))
 )
 @SecurityScheme(
   name = "basicAuth",


### PR DESCRIPTION
Closes #59 

The approach in https://github.com/absa-group/ingestionaas-application/issues/128 didn't work, only an empty string was shown in the url field.

I followed this approach:

https://github.com/springdoc/springdoc-openapi/issues/726

The url is now shown as "/", but the request works