### PR TITLE
#3 add release process support

### DIFF
--- a/.github/workflows/publish_lib.yml
+++ b/.github/workflows/publish_lib.yml
@@ -16,9 +16,8 @@
 
 name: Release - publish client library
 on:
-  push:
-    branches: [master]
-    tags: ["*"]
+  release:
+    types: [released]
 
 jobs:
   publish:

--- a/.github/workflows/publish_lib.yml
+++ b/.github/workflows/publish_lib.yml
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 
-name: Release - publish artifacts
+name: Release - publish client library
 on:
-  release:
-    types: [released]
+  push:
+    branches: [master]
+    tags: ["*"]
 
 jobs:
   publish:

--- a/.github/workflows/publish_lib.yml
+++ b/.github/workflows/publish_lib.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           java-version: "openjdk@1.17.0"
       - name: Build and release to Sonatype and Maven Central
-        run: sbt clientLibrary/ci-release
+        run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/publish_lib.yml
+++ b/.github/workflows/publish_lib.yml
@@ -1,0 +1,38 @@
+#
+# Copyright 2023 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Release - publish artifacts
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v14
+        with:
+          java-version: "openjdk@1.17.0"
+      - name: Build and release to Sonatype and Maven Central
+        run: sbt clientLibrary/ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ ThisBuild / organization := "za.co.absa.login-service"
 lazy val scala212 = "2.12.17"
 
 ThisBuild / scalaVersion := scala212
+ThisBuild / versionScheme := Some("early-semver")
 
 lazy val commonJacocoReportSettings: JacocoReportSettings = JacocoReportSettings(
   formats = Seq(JacocoReportFormats.HTML, JacocoReportFormats.XML)

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ ThisBuild / organization := "za.co.absa.login-service"
 lazy val scala212 = "2.12.17"
 
 ThisBuild / scalaVersion := scala212
-ThisBuild / versionScheme := Some("early-semver")
 
 lazy val commonJacocoReportSettings: JacocoReportSettings = JacocoReportSettings(
   formats = Seq(JacocoReportFormats.HTML, JacocoReportFormats.XML)

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 import Dependencies._
 import com.github.sbt.jacoco.report.JacocoReportSettings
 
-ThisBuild / organization := "za.co.absa.login-service"
+ThisBuild / organization := "za.co.absa"
 
 lazy val scala212 = "2.12.17"
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,8 @@ lazy val api = project // no need to define file, because path is same as val na
     inheritJarManifest := true,
     javacOptions ++= commonJavacOptions,
     jacocoReportSettings := commonJacocoReportSettings.withTitle(s"login-service:service Jacoco Report - scala:${scalaVersion.value}"),
-    jacocoExcludes := commonJacocoExcludes
+    jacocoExcludes := commonJacocoExcludes,
+    publish / skip := true
   ).enablePlugins(TomcatPlugin)
   .enablePlugins(AutomateHeaderPlugin)
 
@@ -56,6 +57,7 @@ lazy val examples = project // no need to define file, because path is same as v
   .settings(
     name := "login-service-examples",
     libraryDependencies ++= exampleDependencies,
-    javacOptions ++= commonJavacOptions
+    javacOptions ++= commonJavacOptions,
+    publish / skip := true
   ).enablePlugins(AutomateHeaderPlugin)
   .dependsOn(clientLibrary)

--- a/clientLibrary/README.md
+++ b/clientLibrary/README.md
@@ -1,3 +1,5 @@
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/za.co.absa/login-service-client-library_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/za.co.absa/login-service-client-library_2.12/)
+
 # Login-service client library
 
 This library provides client-functionality for the login-service.
@@ -10,12 +12,12 @@ Include the library in your project:
 `<dependency>
     <groupId>za.co.absa</groupId>
     <artifactId>login-service-client-library_2.12</artifactId>
-    <version>$VERSION</version>
+    <version>1.0.0</version>
 </dependency>`
 
 ### SBT
 
-`libraryDependencies += "za.co.absa" % "login-service-client-library_2.12" % "0.1.0-SNAPSHOT"`
+`libraryDependencies += "za.co.absa" % "login-service-client-library_2.12" % "1.0.0"`
 
 See the [examples](examples)
 for a more detailed view of how to use the library.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,6 +15,7 @@
 
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.2.4")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 
 // sbt-jacoco - workaround related dependencies required to download
 lazy val ow2Version = "9.5"

--- a/publish.sbt
+++ b/publish.sbt
@@ -52,14 +52,3 @@ ThisBuild / description := "Login service for JWT public signing services"
 ThisBuild / organizationName := "ABSA Group Limited"
 ThisBuild / startYear := Some(2023)
 ThisBuild / licenses += "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")
-
-ThisBuild / pomIncludeRepository := { _ => false }
-ThisBuild / publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (isSnapshot.value) {
-    Some("snapshots" at s"${nexus}content/repositories/snapshots")
-  } else {
-    Some("releases" at s"${nexus}service/local/staging/deploy/maven2")
-  }
-}
-ThisBuild / publishMavenStyle := true

--- a/publish.sbt
+++ b/publish.sbt
@@ -52,6 +52,3 @@ ThisBuild / description := "Login service for JWT public signing services"
 ThisBuild / organizationName := "ABSA Group Limited"
 ThisBuild / startYear := Some(2023)
 ThisBuild / licenses += "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")
-
-ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
-sonatypeRepository := "https://s01.oss.sonatype.org/service/local"

--- a/publish.sbt
+++ b/publish.sbt
@@ -52,3 +52,6 @@ ThisBuild / description := "Login service for JWT public signing services"
 ThisBuild / organizationName := "ABSA Group Limited"
 ThisBuild / startYear := Some(2023)
 ThisBuild / licenses += "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")
+
+ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
+sonatypeRepository := "https://s01.oss.sonatype.org/service/local"


### PR DESCRIPTION
Added new Workflow that publishes Client Library to Sonatype. This utilizes ci-release dependency. Passwords and Access Keys for the github actions are stored in Secrets.

I have not used Github actions before, so please let me know if the workflow is correct or if their are further changes needed.