### PR TITLE
Scala Crossbuild of Client Library with Scala 2.13 (#93)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           java-version: "adopt@1.8"
       - name: Build and run tests
-        run: sbt test doc
+        run: sbt +test +doc

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,14 @@ lazy val commonJacocoExcludes: Seq[String] = Seq(
 
 lazy val commonJavacOptions = Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 
+lazy val parent = (project in file("."))
+  .aggregate(api, clientLibrary, examples)
+  .settings(
+    name := "login-service",
+    javacOptions ++= commonJavacOptions,
+    publish / skip := true
+  )
+
 lazy val api = project // no need to define file, because path is same as val name
   .settings(
     name := "login-service-api",
@@ -52,6 +60,7 @@ lazy val clientLibrary = project // no need to define file, because path is same
     name := "login-service-client-library",
     libraryDependencies ++= clientLibDependencies,
     javacOptions ++= commonJavacOptions,
+    crossScalaVersions := Seq(scala212, "2.13.12")
   ).enablePlugins(AutomateHeaderPlugin)
 
 lazy val examples = project // no need to define file, because path is same as val name

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ import com.github.sbt.jacoco.report.JacocoReportSettings
 ThisBuild / organization := "za.co.absa"
 
 lazy val scala212 = "2.12.17"
+lazy val scala213 = "2.13.12"
 
 ThisBuild / scalaVersion := scala212
 ThisBuild / versionScheme := Some("early-semver")
@@ -60,7 +61,7 @@ lazy val clientLibrary = project // no need to define file, because path is same
     name := "login-service-client-library",
     libraryDependencies ++= clientLibDependencies,
     javacOptions ++= commonJavacOptions,
-    crossScalaVersions := Seq(scala212, "2.13.12")
+    crossScalaVersions := Seq(scala212, scala213)
   ).enablePlugins(AutomateHeaderPlugin)
 
 lazy val examples = project // no need to define file, because path is same as val name

--- a/clientLibrary/src/main/scala/za/co/absa/loginclient/authorization/AccessTokenVerificator.scala
+++ b/clientLibrary/src/main/scala/za/co/absa/loginclient/authorization/AccessTokenVerificator.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.loginclient.authorization
 
-import org.springframework.security.oauth2.jwt.{Jwt, JwtDecoder, NimbusJwtDecoder}
+import org.springframework.security.oauth2.jwt.{Jwt, JwtDecoder}
 import za.co.absa.loginclient.exceptions.LsJwtException
 import za.co.absa.loginclient.tokenRetrieval.model.AccessToken
 

--- a/clientLibrary/src/main/scala/za/co/absa/loginclient/authorization/JwtDecoderProvider.scala
+++ b/clientLibrary/src/main/scala/za/co/absa/loginclient/authorization/JwtDecoderProvider.scala
@@ -16,9 +16,8 @@
 
 package za.co.absa.loginclient.authorization
 
-import org.springframework.security.oauth2.jwt.{Jwt, JwtDecoder, NimbusJwtDecoder}
+import org.springframework.security.oauth2.jwt.{JwtDecoder, NimbusJwtDecoder}
 import za.co.absa.loginclient.publicKeyRetrieval.model.PublicKey
-import za.co.absa.loginclient.tokenRetrieval.model.{AccessToken, RefreshToken}
 
 import java.security.KeyFactory
 import java.security.interfaces.RSAPublicKey

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,6 @@ object Dependencies {
 
   lazy val jwtDecoder = "org.springframework.security" % "spring-security-oauth2-jose" % Versions.spring
   lazy val nimbusJoseJwt = "com.nimbusds" % "nimbus-jose-jwt" % Versions.nimbusJoseJwt
-  lazy val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.70"
 
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig" % Versions.pureConfig
   lazy val pureConfigYaml = "com.github.pureconfig" %% "pureconfig-yaml" % Versions.pureConfig
@@ -110,11 +109,8 @@ object Dependencies {
 
     nimbusJoseJwt,
     jwtDecoder,
-    bouncyCastle,
 
     jjwtApi,
-    jjwtImpl,
-    jjwtJackson,
 
     jsonParser,
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -111,6 +111,8 @@ object Dependencies {
     jwtDecoder,
 
     jjwtApi,
+    jjwtImpl,
+    jjwtJackson,
 
     jsonParser,
 


### PR DESCRIPTION
Created a Package of the Client Library for Scala 2.13.

Please let me know if any other scala versions require compatibility?

Also included some general cleanup of imports and a change to the Build.sbt to avoid publishing of the root project to Sonatype.