### PR TITLE
Ldap Configurable fields changed from List to Map (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ Please ensure at least one auth method is enabled.
 The config also allows the user to specify additional claims to be added to the JWT token. 
 These can be sourced from ldap or specified directly in the config depending on the auth provider used.
 
+Format of attributes list under LDAP in config is:
+```
+        ldap:
+          # Auth Protocol
+          # Set the order of the protocol starting from 1
+          # Set to 0 to disable or simply exclude the ldap tag from config
+          # NOTE: At least 1 auth protocol needs to be enabled
+          order: 2
+          domain: "some.domain.com"
+          url: "ldaps://some.domain.com:636/"
+          search-filter: "(samaccountname={1})"
+          attributes:
+            <ldapFieldName>: "<claimName>"
+```
+
+`ldapFieldName` is the name of the field in the LDAP server and `claimName` is the name of the claim that will be added to the JWT token.
+
 ### ActiveDirectoryLDAPAuthenticationProvider
 Uses LDAP(s) to authenticate user in Active Directory and to fetch groups that this user belongs to.
 

--- a/api/src/main/resources/example.application.yaml
+++ b/api/src/main/resources/example.application.yaml
@@ -62,6 +62,8 @@ loginsvc:
           url: "ldaps://some.domain.com:636/"
           search-filter: "(samaccountname={1})"
           attributes:
+            # The FieldName is the key used to search ldap and the value is the value used to name the JWT claim.
+            # ldapFieldName: claimFieldName
             mail: "email"
             displayname: "displayname"
 

--- a/api/src/main/resources/example.application.yaml
+++ b/api/src/main/resources/example.application.yaml
@@ -51,7 +51,7 @@ loginsvc:
                 - "groupB"
               attributes:
                 displayname: "Test User, A.C.E."
-                mail: "test@abs.com"
+                email: "test@abs.com"
         ldap:
           # Auth Protocol
           # Set the order of the protocol starting from 1
@@ -62,8 +62,8 @@ loginsvc:
           url: "ldaps://some.domain.com:636/"
           search-filter: "(samaccountname={1})"
           attributes:
-            - "mail"
-            - "displayname"
+            mail: "email"
+            displayname: "displayname"
 
 # App Config
 spring:

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfig.scala
@@ -27,7 +27,7 @@ import za.co.absa.loginsvc.rest.config.validation.{ConfigValidatable, ConfigVali
  * @param url URL to AD LDAP, ex. "ldaps://some.domain.com:636/"
  * @param searchFilter LDAP filter used when searching for groups, ex. "(samaccountname={1})"
  */
-case class ActiveDirectoryLDAPConfig(domain: String, url: String, searchFilter: String, order: Int, attributes: Option[Array[String]])
+case class ActiveDirectoryLDAPConfig(domain: String, url: String, searchFilter: String, order: Int, attributes: Option[Map[String, String]])
   extends ConfigValidatable with DynamicAuthOrder
 {
 

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
@@ -98,9 +98,9 @@ class ActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfi
                                      authorities: util.Collection[_ <: GrantedAuthority]
                                    ): UserDetails = {
       val fromBase = super.mapUserFromContext(ctx, username, authorities)
-      val extraAttributes = attributes.map { attr =>
-        val value = Option(ctx.getAttributes().get(attr._1)).map(_.get())
-        attr._2 -> value
+      val extraAttributes = attributes.map { case (fieldName, claimName) =>
+        val value = Option(ctx.getAttributes().get(fieldName)).map(_.get())
+        claimName -> value
       }
 
       UserDetailsWithExtras(fromBase, extraAttributes)

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
@@ -43,7 +43,7 @@ class ActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfi
     val impl = new SpringSecurityActiveDirectoryLdapAuthenticationProvider(config.domain, config.url)
 
     impl.setSearchFilter(config.searchFilter)
-    impl.setUserDetailsContextMapper(new LDAPUserDetailsContextMapperWithOptions(config.attributes.getOrElse(Array.empty)))
+    impl.setUserDetailsContextMapper(new LDAPUserDetailsContextMapperWithOptions(config.attributes.getOrElse(Map.empty)))
 
     impl
   }
@@ -90,7 +90,7 @@ class ActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfi
     override def isEnabled: Boolean = userDetails.isEnabled
   }
 
-  private class LDAPUserDetailsContextMapperWithOptions(attributes: Array[String]) extends LdapUserDetailsMapper {
+  private class LDAPUserDetailsContextMapperWithOptions(attributes: Map[String, String]) extends LdapUserDetailsMapper {
 
     override def mapUserFromContext(
                                      ctx: DirContextOperations,
@@ -99,9 +99,9 @@ class ActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfi
                                    ): UserDetails = {
       val fromBase = super.mapUserFromContext(ctx, username, authorities)
       val extraAttributes = attributes.map { attr =>
-        val value = Option(ctx.getAttributes().get(attr)).map(_.get())
-        attr -> value
-      }.toMap
+        val value = Option(ctx.getAttributes().get(attr._1)).map(_.get())
+        attr._2 -> value
+      }
 
       UserDetailsWithExtras(fromBase, extraAttributes)
     }

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -19,8 +19,8 @@ loginsvc:
           url: "ldaps://some.domain.com:636/"
           search-filter: "(samaccountname={1})"
           attributes:
-            - "mail"
-            - "displayname"
+            mail: "email"
+            displayname: "displayname"
         # Users (config-defined)
         users:
           order: 0

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
@@ -34,40 +34,38 @@ class ConfigProviderTest extends AnyFlatSpec with Matchers  {
 
   "The baseConfig properties" should "Match" in {
     val baseConfig: BaseConfig = configProvider.getBaseConfig
-    assert(baseConfig.someKey == "BETA")
+    baseConfig.someKey shouldBe "BETA"
   }
 
   "The jwtConfig properties" should "Match" in {
     val keyConfig: KeyConfig = configProvider.getJwtKeyConfig
-    assert(keyConfig.algName == "RS256" &&
-      keyConfig.accessExpTime == FiniteDuration(15, TimeUnit.MINUTES) &&
-      keyConfig.refreshExpTime == FiniteDuration(10, TimeUnit.HOURS) &&
-      keyConfig.keyRotationTime.get == FiniteDuration(5, TimeUnit.SECONDS)
-    )
+    keyConfig.algName shouldBe "RS256"
+    keyConfig.accessExpTime shouldBe FiniteDuration(15, TimeUnit.MINUTES)
+    keyConfig.refreshExpTime shouldBe FiniteDuration(10, TimeUnit.HOURS)
+    keyConfig.keyRotationTime.get shouldBe FiniteDuration(5, TimeUnit.SECONDS)
   }
 
   "The ldapConfig properties" should "Match" in {
     val activeDirectoryLDAPConfig: ActiveDirectoryLDAPConfig = configProvider.getLdapConfig
-    assert(activeDirectoryLDAPConfig.url == "ldaps://some.domain.com:636/" &&
-      activeDirectoryLDAPConfig.domain  == "some.domain.com" &&
-      activeDirectoryLDAPConfig.searchFilter  == "(samaccountname={1})" &&
-      activeDirectoryLDAPConfig.order  == 1 &&
-      activeDirectoryLDAPConfig.attributes.get.equals(Map("mail" -> "email", "displayname" -> "displayname")))
+    activeDirectoryLDAPConfig.url shouldBe "ldaps://some.domain.com:636/"
+    activeDirectoryLDAPConfig.domain shouldBe "some.domain.com"
+    activeDirectoryLDAPConfig.searchFilter shouldBe "(samaccountname={1})"
+    activeDirectoryLDAPConfig.order shouldBe 1
+    activeDirectoryLDAPConfig.attributes shouldBe Some(Map("mail" -> "email", "displayname" -> "displayname"))
   }
 
   "The usersConfig properties" should "be loaded correctly" in {
     val usersConfig: UsersConfig = configProvider.getUsersConfig
-    assert(usersConfig.order == 0)
+    usersConfig.order shouldBe 0
 
-    assert(usersConfig.knownUsers(0).groups(0) == "group1" &&
-      usersConfig.knownUsers(0).attributes.isEmpty &&
-      usersConfig.knownUsers(0).password == "password1" &&
-      usersConfig.knownUsers(0).username == "user1")
+    usersConfig.knownUsers(0).groups(0) shouldBe "group1"
+    usersConfig.knownUsers(0).attributes shouldBe None
+    usersConfig.knownUsers(0).password shouldBe "password1"
+    usersConfig.knownUsers(0).username shouldBe "user1"
 
-    assert(usersConfig.knownUsers(1).groups(0) == "group2" &&
-      usersConfig.knownUsers(1).attributes.get.equals(
-        Map("mail" -> "user@two.org", "displayname" -> "User Two")
-      ) && usersConfig.knownUsers(1).password == "password2" &&
-      usersConfig.knownUsers(1).username == "user2")
+    usersConfig.knownUsers(1).groups(0) shouldBe "group2"
+    usersConfig.knownUsers(1).attributes shouldBe Some(Map("mail" -> "user@two.org", "displayname" -> "User Two"))
+    usersConfig.knownUsers(1).password shouldBe "password2"
+    usersConfig.knownUsers(1).username shouldBe "user2"
   }
 }

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
@@ -52,7 +52,7 @@ class ConfigProviderTest extends AnyFlatSpec with Matchers  {
       activeDirectoryLDAPConfig.domain  == "some.domain.com" &&
       activeDirectoryLDAPConfig.searchFilter  == "(samaccountname={1})" &&
       activeDirectoryLDAPConfig.order  == 1 &&
-      (activeDirectoryLDAPConfig.attributes.get sameElements Array("mail", "displayname")))
+      activeDirectoryLDAPConfig.attributes.get.equals(Map("mail" -> "email", "displayname" -> "displayname")))
   }
 
   "The usersConfig properties" should "be loaded correctly" in {


### PR DESCRIPTION
Change made to be able to accommodate difference in Ldap key names and claim key names.

Closes Issue: https://github.com/AbsaOSS/login-service/issues/98