### PR TITLE
#45 a suggestion to add sso to be able to use `aws sso login` to dev-launch LS

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,6 +61,7 @@ object Dependencies {
 
   lazy val awsSecrets = "software.amazon.awssdk" % "secretsmanager" % "2.20.68"
   lazy val awsSts = "software.amazon.awssdk" % "sts" % "2.20.69"
+  lazy val awsSoo = "software.amazon.awssdk" % "sso" % "2.20.69"
 
   lazy val servletApi = "javax.servlet" % "javax.servlet-api" % "3.0.1" % Provided
 
@@ -100,6 +101,7 @@ object Dependencies {
 
     awsSecrets,
     awsSts,
+    awsSoo,
 
     springDoc,
 


### PR DESCRIPTION
With this update, `aws sso login` works for me to enable local LS to run and be able to load data from AWS services withing `npintdebdtools` account