### PR TITLE
Expiration now based on Current Key Create Time instead of Previous key create time

### DIFF
--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
@@ -53,7 +53,8 @@ case class AwsSecretsManagerKeyConfig(
       if(currentSecretsOption.isEmpty)
         throw new Exception("Error retrieving AWSCURRENT key from from AWS Secrets Manager")
 
-      val currentKeyPair = createKeyPair(currentSecretsOption.get.secretValue)
+      val currentSecrets = currentSecretsOption.get
+      val currentKeyPair = createKeyPair(currentSecrets.secretValue)
       logger.info("AWSCURRENT Key Data successfully retrieved and parsed from AWS Secrets Manager")
 
       val previousSecretsOption =
@@ -68,7 +69,7 @@ case class AwsSecretsManagerKeyConfig(
         try {
           val keys = createKeyPair(previousSecrets.secretValue)
           logger.info("AWSPREVIOUS Key Data successfully retrieved and parsed from AWS Secrets Manager")
-          val exp = keyPhaseOutTime.exists(isExpired(previousSecrets.createTime, _))
+          val exp = keyPhaseOutTime.exists(isExpired(currentSecrets.createTime, _))
           if(exp) { None }
           else { Some(keys) }
         } catch {


### PR DESCRIPTION
Release Notes:
-  Use Current Key creation time to calculate expiration of keys instead of Previous Key Creation Time.

Minor BugFix for Key Phase expiry being based on the previous keys creation time. This is incorrect as this reflects the previous rotation time and therefore the key will always be expired.

We need to base the expiry time on the creation time of the current key as that's the latest rotation time.

closes #114 