### PR TITLE
Fix JWT Match in JWTService.scala

### DIFF
--- a/api/src/main/scala/za/co/absa/loginsvc/rest/service/jwt/JWTService.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/service/jwt/JWTService.scala
@@ -194,8 +194,9 @@ class JWTService @Autowired()(jwtConfigProvider: JwtConfigProvider, authSearchSe
           logger.info("Keys have been Refreshed")
           jwtConfig.keyPhaseOutTime.foreach { kp => {
             jwtConfig match {
-              case i: InMemoryKeyConfig =>
+              case _: InMemoryKeyConfig =>
                 scheduleKeyPhaseOut(kp)
+              case _ =>
             }
           }}
           primaryKeyPair = newPrimaryKeyPair


### PR DESCRIPTION
Release Notes:
- Minor Bug Fix to JWTService.scala

Additional Fix for missing default case when inMemoryConfig isn't used

closes #114 