### PR TITLE
117 delay option for new set of key signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ AbsaOSS Common Login service using JWT Public key signatures
 To interact with the service, most notable endpoints are
  - `/token/generate` to generate access & refresh tokens
  - `/token/refresh` to obtain a new access token with a still-valid refresh token
- - `/token/public-key` to obtain public key to verify tokens including their validity window
+ - `/token/public-key` to obtain the currently signing public key to verify tokens including their validity window
+ - `/token/public-keys` to obtain all available public keys including the current and previously rotated keys.
+ - `/token/public-key-jwks` gives same data as `/token/public-keys` but in the form of a JSON Web Key Set.
 
 Please, refer to the [API documentation](#api-documentation) below for details of the endpoints.
 
@@ -201,13 +203,27 @@ loginsvc:
          access-exp-time: 15min
          refresh-exp-time: 9h
          key-rotation-time: 9h
+         key-lay-over-time: 15min
+         key-phase-out-time: 30min
          alg-name: "RS256"
 ```
 There are a few important configuration values to be provided:
 - `access-exp-time` which indicates how long an access token is valid for,
 - `refresh-exp-time` which indicates how long a refresh token is valid for,
 - Optional property: `key-rotation-time` which indicates how often Key pairs are rotated. Rotation will be disabled if missing.
+- Optional property: `key-lay-over-time` which indicates a delay after rotation before using the newly created key for signing. Lay-over will be disabled if missing.
+- Optional property: `key-phase-out-time` which indicates the time to phase out the older key. Timer is scheduled after `key-lay-over-time` if enabled. Phase-out will be disabled if missing.
 - `alg-name` which indicates which algorithm is used to encode your keys.
+
+Using the above values, the optional properties will give the following effect after the 1st rotation at 9 hours:
+```
+t=0: keys rotation happens
+t=0-14m: layover period: old key from before rotation is still used for signing. Both public keys available from public-keys endpoint.
+t=15-29m: layover is over: new key from after rotation is used for signing. Both public keys available from public-keys endpoint.
+t=30m+: phase-out happens: new key from after rotation is used for signing. Old Key is no longer available from public-keys endpoint.
+```
+These properties cannot be enabled if rotation is not enabled. The combined values of these properties cannot be higher than the rotation time.
+
 
 To setup for AWS Secrets Manager, your config should look like so:
 ```
@@ -222,6 +238,8 @@ loginsvc:
         access-exp-time: 15min
         refresh-exp-time: 9h
         poll-time: 30min
+        key-lay-over-time: 15min
+        key-phase-out-time: 30min
         alg-name: "RS256"
 ```
 Your AWS Secret must have at least 2 fields which correspond to the above properties:
@@ -236,7 +254,17 @@ There are a few important configuration values to be provided:
 - `access-exp-time` which indicates how long an access token is valid for,
 - `refresh-exp-time` which indicates how long a refresh token is valid for,
 - Optional property:`poll-time` which indicates how often key pairs (`private-key-field-name` and `public-key-field-name`) are polled and fetched from AWS Secrets Manager. Polling will be disabled if missing.
+- Optional property: `key-lay-over-time` which indicates a delay after rotation before using the newly created key for signing. Lay-over will be disabled if missing.
+- Optional property: `key-phase-out-time` which indicates the time to phase out the older key. Timer is scheduled after `key-lay-over-time` if enabled. Phase-out will be disabled if missing.
 - `alg-name` which indicates which algorithm is used to encode your keys.
+  Using the above values, the optional properties will give the following effect after the 1st rotation at 9 hours:
+```
+t=0: keys rotation happens
+t=0-14m: layover period: old key from before rotation is still used for signing. Both public keys available from public-keys endpoint.
+t=15-29m: layover is over: new key from after rotation is used for signing. Both public keys available from public-keys endpoint.
+t=30m+: phase-out happens: new key from after rotation is used for signing. Old Key is no longer available from public-keys endpoint.
+```
+These properties cannot be enabled if polling is not enabled.
   
 Please note that only one configuration option (`loginsvc.rest.jwt.{aws-secrets-manager|generate-in-memory}`) can be used at a time.
 

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ Using the above values, the optional properties will give the following effect a
 ```
 t=0: keys rotation happens
 t=0-14m: layover period: old key from before rotation is still used for signing. Both public keys available from public-keys endpoint.
-t=15-29m: layover is over: new key from after rotation is used for signing. Both public keys available from public-keys endpoint.
-t=30m+: phase-out happens: new key from after rotation is used for signing. Old Key is no longer available from public-keys endpoint.
+t=15-44m: layover is over: new key from after rotation is used for signing. Both public keys available from public-keys endpoint.
+t=45m+: phase-out happens: new key from after rotation is used for signing. Old Key is no longer available from public-keys endpoint.
 ```
 These properties cannot be enabled if rotation is not enabled. The combined values of these properties cannot be higher than the rotation time.
 
@@ -261,8 +261,8 @@ There are a few important configuration values to be provided:
 ```
 t=0: keys rotation happens
 t=0-14m: layover period: old key from before rotation is still used for signing. Both public keys available from public-keys endpoint.
-t=15-29m: layover is over: new key from after rotation is used for signing. Both public keys available from public-keys endpoint.
-t=30m+: phase-out happens: new key from after rotation is used for signing. Old Key is no longer available from public-keys endpoint.
+t=15-44m: layover is over: new key from after rotation is used for signing. Both public keys available from public-keys endpoint.
+t=45m+: phase-out happens: new key from after rotation is used for signing. Old Key is no longer available from public-keys endpoint.
 ```
 These properties cannot be enabled if polling is not enabled.
   

--- a/api/src/main/resources/example.application.yaml
+++ b/api/src/main/resources/example.application.yaml
@@ -8,6 +8,7 @@ loginsvc:
         refresh-exp-time: 9h
         key-rotation-time: 9h
         key-phase-out-time: 30min
+        key-lay-over-time: 15min
         alg-name: "RS256"
       #Instead of generating the key in memory
       #The Below Config allows for the application to fetch keys from AWS Secrets Manager.
@@ -58,7 +59,7 @@ loginsvc:
           # Set the order of the protocol starting from 1
           # Set to 0 to disable or simply exclude the ldap tag from config
           # NOTE: At least 1 auth protocol needs to be enabled
-          order: 0
+          order: 2
           domain: "some.domain.com"
           url: "ldaps://some.domain.com:636/"
           search-filter: "(samaccountname={1})"
@@ -103,7 +104,7 @@ management:
   health:
     ldap:
       # TODO: Enable Ldap check for actuator/health when fully Implemented - issue #34
-      enabled: "false"
+      enabled: "true"
   # Expose information under Actuator/info
   info:
     # Exposes any property marked under "info" in the config

--- a/api/src/main/resources/example.application.yaml
+++ b/api/src/main/resources/example.application.yaml
@@ -59,7 +59,7 @@ loginsvc:
           # Set the order of the protocol starting from 1
           # Set to 0 to disable or simply exclude the ldap tag from config
           # NOTE: At least 1 auth protocol needs to be enabled
-          order: 2
+          order: 0
           domain: "some.domain.com"
           url: "ldaps://some.domain.com:636/"
           search-filter: "(samaccountname={1})"
@@ -104,7 +104,7 @@ management:
   health:
     ldap:
       # TODO: Enable Ldap check for actuator/health when fully Implemented - issue #34
-      enabled: "true"
+      enabled: "false"
   # Expose information under Actuator/info
   info:
     # Exposes any property marked under "info" in the config

--- a/api/src/main/resources/example.application.yaml
+++ b/api/src/main/resources/example.application.yaml
@@ -7,8 +7,8 @@ loginsvc:
         access-exp-time: 15min
         refresh-exp-time: 9h
         key-rotation-time: 9h
-        key-phase-out-time: 30min
         key-lay-over-time: 15min
+        key-phase-out-time: 15min
         alg-name: "RS256"
       #Instead of generating the key in memory
       #The Below Config allows for the application to fetch keys from AWS Secrets Manager.
@@ -20,7 +20,8 @@ loginsvc:
         #access-exp-time: 15min
         #refresh-exp-time: 9h
         #poll-time: 5min
-        #key-phase-out-time: 30min
+        #key-lay-over-time: 15min
+        #key-phase-out-time: 15min
         #alg-name: "RS256"
     config:
       # Generates git.properties file for use on info endpoint.

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
@@ -80,7 +80,15 @@ case class AwsSecretsManagerKeyConfig(
         }
       }
 
-      (currentKeyPair, previousKeyPair)
+      previousKeyPair.fold {(currentKeyPair, previousKeyPair)} { pk =>
+        val exp = keyLayOverTime.exists(isExpired(currentSecrets.createTime, _))
+        if (exp) {
+          (currentKeyPair, previousKeyPair)
+        }
+        else {
+          (pk, Some(currentKeyPair))
+        }
+      }
     } catch {
       case e: Throwable =>
         logger.error(s"Error occurred retrieving and decoding keys from AWS Secrets Manager", e)

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
@@ -78,7 +78,7 @@ case class AwsSecretsManagerKeyConfig(
    *
    * @param secretsUtils The methods used to fetch the keys.
    *                     Mainly used for testing and can be left empty to use the default value in standard use.
-   * @return The most current KeyPair as well as an option of the previously rotated keypair if available.
+   * @return A tuple of the most current KeyPair as well as an option of the previously rotated keypair if available.
    *         The order and availability of the keys are dependant on key-lay-over and key-phase-out if enabled.
    */
   private[jwt] def fetchKeySetsFromCloud(secretsUtils: SecretUtils = AwsSecretsUtils): (KeyPair, Option[KeyPair]) = {

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
@@ -36,7 +36,8 @@ case class AwsSecretsManagerKeyConfig(
   accessExpTime: FiniteDuration,
   refreshExpTime: FiniteDuration,
   pollTime: Option[FiniteDuration],
-  keyPhaseOutTime: Option[FiniteDuration]
+  keyPhaseOutTime: Option[FiniteDuration],
+  keyLayOverTime: Option[FiniteDuration]
 ) extends KeyConfig {
 
   private val logger = LoggerFactory.getLogger(classOf[AwsSecretsManagerKeyConfig])

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
@@ -81,8 +81,8 @@ case class AwsSecretsManagerKeyConfig(
       }
 
       previousKeyPair.fold {(currentKeyPair, previousKeyPair)} { pk =>
-        val exp = keyLayOverTime.exists(isExpired(currentSecrets.createTime, _))
-        if (exp) {
+        val exp = keyLayOverTime.exists(!isExpired(currentSecrets.createTime, _))
+        if (!exp) {
           (currentKeyPair, previousKeyPair)
         }
         else {

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
@@ -25,7 +25,7 @@ import java.security.{KeyFactory, KeyPair}
 import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
 import java.time.Instant
 import java.util.Base64
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 case class AwsSecretsManagerKeyConfig(
   secretName: String,
@@ -70,7 +70,8 @@ case class AwsSecretsManagerKeyConfig(
         try {
           val keys = createKeyPair(previousSecrets.secretValue)
           logger.info("AWSPREVIOUS Key Data successfully retrieved and parsed from AWS Secrets Manager")
-          val exp = keyPhaseOutTime.exists(isExpired(currentSecrets.createTime, _))
+          val exp = keyPhaseOutTime.exists(kpot =>
+            isExpired(currentSecrets.createTime, kpot + keyLayOverTime.getOrElse(Duration.Zero)))
           if(exp) { None }
           else { Some(keys) }
         } catch {

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
@@ -36,8 +36,8 @@ case class AwsSecretsManagerKeyConfig(
   accessExpTime: FiniteDuration,
   refreshExpTime: FiniteDuration,
   pollTime: Option[FiniteDuration],
-  keyPhaseOutTime: Option[FiniteDuration],
-  keyLayOverTime: Option[FiniteDuration]
+  keyLayOverTime: Option[FiniteDuration],
+  keyPhaseOutTime: Option[FiniteDuration]
 ) extends KeyConfig {
 
   private val logger = LoggerFactory.getLogger(classOf[AwsSecretsManagerKeyConfig])

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
@@ -77,7 +77,8 @@ case class AwsSecretsManagerKeyConfig(
       val currentSecretsOption = secretsUtils.fetchSecret(
         secretName,
         region,
-        Array(privateKeyFieldName, publicKeyFieldName)
+        Array(privateKeyFieldName, publicKeyFieldName),
+        None
       )
 
       if(currentSecretsOption.isEmpty)

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfig.scala
@@ -19,7 +19,7 @@ package za.co.absa.loginsvc.rest.config.jwt
 import org.slf4j.LoggerFactory
 import za.co.absa.loginsvc.rest.config.validation.{ConfigValidationException, ConfigValidationResult}
 import za.co.absa.loginsvc.rest.config.validation.ConfigValidationResult.{ConfigValidationError, ConfigValidationSuccess}
-import za.co.absa.loginsvc.utils.{AwsSecretsUtils, SecretUtil}
+import za.co.absa.loginsvc.utils.{AwsSecretsUtils, SecretUtils}
 
 import java.security.{KeyFactory, KeyPair}
 import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
@@ -72,7 +72,16 @@ case class AwsSecretsManagerKeyConfig(
     super.validate().merge(awsSecretsResultsMerge)
   }
 
-  def fetchKeySetsFromCloud(secretsUtils: SecretUtil = AwsSecretsUtils): (KeyPair, Option[KeyPair]) = {
+  /**
+   * Fetches the keypair used for generating Java Web Tokens from Cloud.
+   * Fetches both the current as well as previously rotated keys if available.
+   *
+   * @param secretsUtils The methods used to fetch the keys.
+   *                     Mainly used for testing and can be left empty to use the default value in standard use.
+   * @return The most current KeyPair as well as an option of the previously rotated keypair if available.
+   *         The order and availability of the keys are dependant on key-lay-over and key-phase-out if enabled.
+   */
+  private[jwt] def fetchKeySetsFromCloud(secretsUtils: SecretUtils = AwsSecretsUtils): (KeyPair, Option[KeyPair]) = {
     try {
       val currentSecretsOption = secretsUtils.fetchSecret(
         secretName,

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfig.scala
@@ -30,7 +30,8 @@ case class InMemoryKeyConfig(
   accessExpTime: FiniteDuration,
   refreshExpTime: FiniteDuration,
   keyRotationTime: Option[FiniteDuration],
-  keyPhaseOutTime: Option[FiniteDuration]
+  keyPhaseOutTime: Option[FiniteDuration],
+  keyLayOverTime: Option[FiniteDuration]
 ) extends KeyConfig {
 
   private var oldKeyPair: Option[KeyPair] = None
@@ -50,7 +51,14 @@ case class InMemoryKeyConfig(
       ConfigValidationError(ConfigValidationException(s"keyPhaseOutTime must be lower than keyRotationTime!"))
     } else ConfigValidationSuccess
 
-    super.validate().merge(keyPhaseOutTimeResult)
+    val keyLayOverTimeResult = if(keyLayOverTime.nonEmpty && keyRotationTime.nonEmpty
+      && keyLayOverTime.get > keyRotationTime.get) {
+      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be lower than keyRotationTime!"))
+    } else ConfigValidationSuccess
+
+    super.validate()
+      .merge(keyPhaseOutTimeResult)
+      .merge(keyLayOverTimeResult)
   }
 
   override def throwErrors(): Unit = this.validate().throwOnErrors()

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfig.scala
@@ -30,8 +30,8 @@ case class InMemoryKeyConfig(
   accessExpTime: FiniteDuration,
   refreshExpTime: FiniteDuration,
   keyRotationTime: Option[FiniteDuration],
-  keyPhaseOutTime: Option[FiniteDuration],
-  keyLayOverTime: Option[FiniteDuration]
+  keyLayOverTime: Option[FiniteDuration],
+  keyPhaseOutTime: Option[FiniteDuration]
 ) extends KeyConfig {
 
   private var oldKeyPair: Option[KeyPair] = None

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/KeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/KeyConfig.scala
@@ -88,11 +88,6 @@ trait KeyConfig extends ConfigValidatable {
       ConfigValidationError(ConfigValidationException(s"keyLayOverTime can only be enable if keyRotationTime is enable!"))
     } else ConfigValidationSuccess
 
-    val keyLayOverWithPhaseResult = if(keyLayOverTime.nonEmpty && keyPhaseOutTime.nonEmpty
-      && keyLayOverTime.get > keyPhaseOutTime.get) {
-      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be lower than keyPhaseOutTime!"))
-    } else ConfigValidationSuccess
-
     if (keyRotationTime.isEmpty) {
       logger.warn("keyRotationTime is not set in config, key-pair will not be rotated!")
     }
@@ -109,7 +104,6 @@ trait KeyConfig extends ConfigValidatable {
       .merge(keyPhaseOutWithRotationResult)
       .merge(keyLayoverTimeResult)
       .merge(keyLayOverWithRotationResult)
-      .merge(keyLayOverWithPhaseResult)
   }
 }
 

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/KeyConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/jwt/KeyConfig.scala
@@ -30,8 +30,8 @@ trait KeyConfig extends ConfigValidatable {
   def accessExpTime: FiniteDuration
   def refreshExpTime: FiniteDuration
   def keyRotationTime: Option[FiniteDuration]
-  def keyPhaseOutTime: Option[FiniteDuration]
   def keyLayOverTime: Option[FiniteDuration]
+  def keyPhaseOutTime: Option[FiniteDuration]
   def keyPair(): (KeyPair, Option[KeyPair])
   def throwErrors(): Unit
 

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/service/jwt/JWTService.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/service/jwt/JWTService.scala
@@ -118,7 +118,7 @@ class JWTService @Autowired()(jwtConfigProvider: JwtConfigProvider, authSearchSe
     ) // checks requirements: type=access, signature, custom validity window
 
     if(oldAccessJws.isEmpty)
-      throw new JwtException("Access token is invalid!")
+      throw new JwtException("Tokens are incompatible with current keys. Please request new Tokens!")
 
     val userFromOldAccessToken: User = extractUserFrom(oldAccessJws.get.getBody)
 
@@ -127,8 +127,9 @@ class JWTService @Autowired()(jwtConfigProvider: JwtConfigProvider, authSearchSe
       keyList,
       Token.TokenType.Refresh.toString
     )
+
     if(refreshClaims.isEmpty)
-      throw new JwtException("refresh Token is invalid!")
+      throw new JwtException("Tokens are incompatible with current keys. Please request new Tokens!")
 
     val userUpdatedDetails = {
       try {

--- a/api/src/main/scala/za/co/absa/loginsvc/utils/AwsSecretsUtils.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/utils/AwsSecretsUtils.scala
@@ -24,7 +24,7 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.secretsmanager.model.{GetSecretValueRequest, GetSecretValueResponse}
 import za.co.absa.loginsvc.rest.model.AwsSecret
 
-object AwsSecretsUtils extends SecretUtil {
+object AwsSecretsUtils extends SecretUtils {
 
   private val logger = LoggerFactory.getLogger(getClass)
   def fetchSecret(
@@ -67,7 +67,7 @@ object AwsSecretsUtils extends SecretUtil {
   }
 }
 
-trait SecretUtil {
+trait SecretUtils {
   def fetchSecret(
     secretName: String,
     region: String,

--- a/api/src/main/scala/za/co/absa/loginsvc/utils/AwsSecretsUtils.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/utils/AwsSecretsUtils.scala
@@ -24,7 +24,7 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.secretsmanager.model.{GetSecretValueRequest, GetSecretValueResponse}
 import za.co.absa.loginsvc.rest.model.AwsSecret
 
-object AwsSecretsUtils {
+object AwsSecretsUtils extends SecretUtil {
 
   private val logger = LoggerFactory.getLogger(getClass)
   def fetchSecret(
@@ -65,4 +65,13 @@ object AwsSecretsUtils {
         None
     }
   }
+}
+
+trait SecretUtil {
+  def fetchSecret(
+    secretName: String,
+    region: String,
+    secretFields: Array[String],
+    versionStage: Option[String] = None
+  ): Option[AwsSecret]
 }

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -5,8 +5,9 @@ loginsvc:
       generate-in-memory:
         access-exp-time: 15min
         refresh-exp-time: 10h
-        key-rotation-time: 5sec
-        key-phase-out-time: 3sec
+        key-rotation-time: 20sec
+        key-phase-out-time: 10sec
+        key-lay-over-time: 5sec
         alg-name: "RS256"
 
     # Rest Auth Config (AD)

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -5,9 +5,9 @@ loginsvc:
       generate-in-memory:
         access-exp-time: 15min
         refresh-exp-time: 10h
-        key-rotation-time: 20sec
-        key-phase-out-time: 10sec
-        key-lay-over-time: 5sec
+        key-rotation-time: 10sec
+        key-lay-over-time: 3sec
+        key-phase-out-time: 3sec
         alg-name: "RS256"
 
     # Rest Auth Config (AD)

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfigTest.scala
@@ -80,11 +80,6 @@ class AwsSecretsManagerKeyConfigTest extends AnyFlatSpec with Matchers {
       ConfigValidationError(ConfigValidationException(s"keyLayOverTime can only be enable if keyRotationTime is enable!"))
   }
 
-  it should "fail on keyLayOverTime being larger than keyPhaseOutTime" in {
-    awsSecretsManagerKeyConfig.copy(keyPhaseOutTime = Option(4.minutes)).validate() shouldBe
-      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be lower than keyPhaseOutTime!"))
-  }
-
   it should "fail on missing value" in {
     awsSecretsManagerKeyConfig.copy(secretName = null).validate() shouldBe
       ConfigValidationError(ConfigValidationException("secretName is empty"))

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfigTest.scala
@@ -33,7 +33,8 @@ class AwsSecretsManagerKeyConfigTest extends AnyFlatSpec with Matchers {
     15.minutes,
     9.minutes,
     Option(30.minutes),
-    Option(15.minutes))
+    Option(15.minutes),
+    Option(5.minutes))
 
   "awsSecretsManagerKeyConfig" should "validate expected content" in {
     awsSecretsManagerKeyConfig.validate() shouldBe ConfigValidationSuccess

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfigTest.scala
@@ -16,16 +16,24 @@
 
 package za.co.absa.loginsvc.rest.config.jwt
 
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import org.mockito.ArgumentMatchers.{any, anyString, eq => eqMatch}
+import org.mockito.Mockito.{mock, when}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.loginsvc.rest.config.validation.ConfigValidationException
 import za.co.absa.loginsvc.rest.config.validation.ConfigValidationResult.{ConfigValidationError, ConfigValidationSuccess}
+import za.co.absa.loginsvc.rest.model.AwsSecret
+import za.co.absa.loginsvc.utils.SecretUtil
 
+import java.time.Instant
+import java.util.Base64
 import scala.concurrent.duration._
 
 class AwsSecretsManagerKeyConfigTest extends AnyFlatSpec with Matchers {
 
-  val awsSecretsManagerKeyConfig: AwsSecretsManagerKeyConfig = AwsSecretsManagerKeyConfig("Secret",
+  private val awsSecretsManagerKeyConfig: AwsSecretsManagerKeyConfig = AwsSecretsManagerKeyConfig("Secret",
     "region",
     "private",
     "public",
@@ -35,6 +43,26 @@ class AwsSecretsManagerKeyConfigTest extends AnyFlatSpec with Matchers {
     Option(30.minutes),
     Option(15.minutes),
     Option(5.minutes))
+
+  private val mockSecretsUtil = mock(classOf[SecretUtil])
+  private val currentKeyPair = Keys.keyPairFor(SignatureAlgorithm.RS256)
+  private val previousKeyPair = Keys.keyPairFor(SignatureAlgorithm.RS256)
+  private val currentkeyPairMaps = Map(
+    "private" -> Base64.getEncoder.encodeToString(currentKeyPair.getPrivate.getEncoded),
+    "public" -> Base64.getEncoder.encodeToString(currentKeyPair.getPublic.getEncoded))
+  private val previouskeyPairMaps = Map(
+    "private" -> Base64.getEncoder.encodeToString(previousKeyPair.getPrivate.getEncoded),
+    "public" -> Base64.getEncoder.encodeToString(previousKeyPair.getPublic.getEncoded))
+
+  private val currentSecret = Some(AwsSecret(currentkeyPairMaps, Instant.now()))
+  private val currentSecretAfterLayOver = Some(AwsSecret(currentkeyPairMaps,
+    Instant.now().minus(16.minutes.toMillis, java.time.temporal.ChronoUnit.MILLIS)))
+  private val currentSecretAfterPhase = Some(AwsSecret(currentkeyPairMaps,
+    Instant.now().minus(21.minutes.toMillis, java.time.temporal.ChronoUnit.MILLIS)))
+  private val previousSecret = Some(AwsSecret(previouskeyPairMaps,
+    Instant.now().minus(6.hours.toMillis, java.time.temporal.ChronoUnit.MILLIS)))
+
+  behavior of "validation"
 
   "awsSecretsManagerKeyConfig" should "validate expected content" in {
     awsSecretsManagerKeyConfig.validate() shouldBe ConfigValidationSuccess
@@ -83,5 +111,82 @@ class AwsSecretsManagerKeyConfigTest extends AnyFlatSpec with Matchers {
   it should "fail on missing value" in {
     awsSecretsManagerKeyConfig.copy(secretName = null).validate() shouldBe
       ConfigValidationError(ConfigValidationException("secretName is empty"))
+  }
+
+  behavior of "fetchKeySetsFromCloud"
+
+  it should "not use keyLayOver when previousKey is not available" in {
+    when (mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(None)))
+      .thenReturn(currentSecret)
+    when(mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(Some("AWSPREVIOUS"))))
+      .thenReturn(None)
+
+    val keysDuringLayover = awsSecretsManagerKeyConfig.fetchKeySetsFromCloud(mockSecretsUtil)
+
+    assert(keysDuringLayover._1.getPrivate == currentKeyPair.getPrivate)
+    assert(keysDuringLayover._1.getPublic == currentKeyPair.getPublic)
+    assert(keysDuringLayover._2.isEmpty)
+
+    when (mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(None))).thenReturn(currentSecretAfterLayOver)
+
+    val keysAfterLayover = awsSecretsManagerKeyConfig.fetchKeySetsFromCloud(mockSecretsUtil)
+
+    assert(keysAfterLayover._1.getPrivate == currentKeyPair.getPrivate)
+    assert(keysAfterLayover._1.getPublic == currentKeyPair.getPublic)
+    assert(keysAfterLayover._2.isEmpty)
+  }
+
+  it should "not use keyPhaseOut when previousKey is not available" in {
+    when (mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(None)))
+      .thenReturn(currentSecretAfterPhase)
+    when(mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(Some("AWSPREVIOUS"))))
+      .thenReturn(None)
+
+    val keysDuringLayover = awsSecretsManagerKeyConfig.fetchKeySetsFromCloud(mockSecretsUtil)
+
+    assert(keysDuringLayover._1.getPrivate == currentKeyPair.getPrivate)
+    assert(keysDuringLayover._1.getPublic == currentKeyPair.getPublic)
+    assert(keysDuringLayover._2.isEmpty)
+  }
+
+  it should "use previousKey during the keyLayOver Period" in {
+    when (mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(None)))
+      .thenReturn(currentSecret)
+    when(mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(Some("AWSPREVIOUS"))))
+      .thenReturn(previousSecret)
+
+    val keysDuringLayover = awsSecretsManagerKeyConfig.fetchKeySetsFromCloud(mockSecretsUtil)
+
+    assert(keysDuringLayover._1.getPrivate == previousKeyPair.getPrivate)
+    assert(keysDuringLayover._1.getPublic == previousKeyPair.getPublic)
+    assert(keysDuringLayover._2.get.getPrivate == currentKeyPair.getPrivate)
+    assert(keysDuringLayover._2.get.getPublic == currentKeyPair.getPublic)
+  }
+
+  it should "use currentKey after the keyLayOver Period" in {
+    when (mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(None)))
+      .thenReturn(currentSecretAfterLayOver)
+    when(mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(Some("AWSPREVIOUS"))))
+      .thenReturn(previousSecret)
+
+    val keysDuringLayover = awsSecretsManagerKeyConfig.fetchKeySetsFromCloud(mockSecretsUtil)
+
+    assert(keysDuringLayover._1.getPrivate == currentKeyPair.getPrivate)
+    assert(keysDuringLayover._1.getPublic == currentKeyPair.getPublic)
+    assert(keysDuringLayover._2.get.getPrivate == previousKeyPair.getPrivate)
+    assert(keysDuringLayover._2.get.getPublic == previousKeyPair.getPublic)
+  }
+
+  it should "set the previousKey to None after the keyPhaseOut period" in {
+    when (mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(None)))
+      .thenReturn(currentSecretAfterPhase)
+    when(mockSecretsUtil.fetchSecret(anyString(),anyString(),any[Array[String]](),eqMatch(Some("AWSPREVIOUS"))))
+      .thenReturn(previousSecret)
+
+    val keysDuringLayover = awsSecretsManagerKeyConfig.fetchKeySetsFromCloud(mockSecretsUtil)
+
+    assert(keysDuringLayover._1.getPrivate == currentKeyPair.getPrivate)
+    assert(keysDuringLayover._1.getPublic == currentKeyPair.getPublic)
+    assert(keysDuringLayover._2.isEmpty)
   }
 }

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/AwsSecretsManagerKeyConfigTest.scala
@@ -61,13 +61,28 @@ class AwsSecretsManagerKeyConfigTest extends AnyFlatSpec with Matchers {
   }
 
   it should "fail on non-negative keyPhaseOutTime" in {
-    awsSecretsManagerKeyConfig.copy(keyPhaseOutTime = Option(5.milliseconds)).validate() shouldBe
+    awsSecretsManagerKeyConfig.copy(keyPhaseOutTime = Option(5.milliseconds), keyLayOverTime = None).validate() shouldBe
       ConfigValidationError(ConfigValidationException(s"keyPhaseOutTime must be at least ${KeyConfig.minKeyPhaseOutTime}"))
   }
 
   it should "fail on keyPhaseOutTime being configured without keyRotationTime" in {
-    awsSecretsManagerKeyConfig.copy(pollTime = None).validate() shouldBe
+    awsSecretsManagerKeyConfig.copy(pollTime = None, keyLayOverTime = None).validate() shouldBe
       ConfigValidationError(ConfigValidationException(s"keyPhaseOutTime can only be enable if keyRotationTime is enable!"))
+  }
+
+  it should "fail on non-negative keyLayOverTime" in {
+    awsSecretsManagerKeyConfig.copy(keyLayOverTime = Option(5.milliseconds)).validate() shouldBe
+      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be at least ${KeyConfig.minKeyLayOverTime}"))
+  }
+
+  it should "fail on keyLayOverTime being configured without keyRotationTime" in {
+    awsSecretsManagerKeyConfig.copy(pollTime = None, keyPhaseOutTime = None).validate() shouldBe
+      ConfigValidationError(ConfigValidationException(s"keyLayOverTime can only be enable if keyRotationTime is enable!"))
+  }
+
+  it should "fail on keyLayOverTime being larger than keyPhaseOutTime" in {
+    awsSecretsManagerKeyConfig.copy(keyPhaseOutTime = Option(4.minutes)).validate() shouldBe
+      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be lower than keyPhaseOutTime!"))
   }
 
   it should "fail on missing value" in {

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfigTest.scala
@@ -29,7 +29,8 @@ class InMemoryKeyConfigTest extends AnyFlatSpec with Matchers {
     15.minutes,
     2.hours,
     Option(30.minutes),
-    Option(15.minutes))
+    Option(15.minutes),
+    Option(5.minutes))
 
   "inMemoryKeyConfig" should "validate expected content" in {
     inMemoryKeyConfig.validate() shouldBe ConfigValidationSuccess
@@ -68,5 +69,25 @@ class InMemoryKeyConfigTest extends AnyFlatSpec with Matchers {
   it should "fail on keyPhaseOutTime being larger than keyRotationTime" in {
     inMemoryKeyConfig.copy(keyRotationTime = Option(10.minutes)).validate() shouldBe
       ConfigValidationError(ConfigValidationException(s"keyPhaseOutTime must be lower than keyRotationTime!"))
+  }
+
+  it should "fail on non-negative keyLayOverTime" in {
+    inMemoryKeyConfig.copy(keyLayOverTime = Option(5.milliseconds)).validate() shouldBe
+      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be at least ${KeyConfig.minKeyLayOverTime}"))
+  }
+
+  it should "fail on keyLayOverTime being configured without keyRotationTime" in {
+    inMemoryKeyConfig.copy(keyRotationTime = None, keyPhaseOutTime = None).validate() shouldBe
+      ConfigValidationError(ConfigValidationException(s"keyLayOverTime can only be enable if keyRotationTime is enable!"))
+  }
+
+  it should "fail on keyLayOverTime being larger than keyRotationTime" in {
+    inMemoryKeyConfig.copy(keyRotationTime = Option(4.minutes), keyPhaseOutTime = None).validate() shouldBe
+      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be lower than keyRotationTime!"))
+  }
+
+  it should "fail on keyLayOverTime being larger than keyPhaseOutTime" in {
+    inMemoryKeyConfig.copy(keyPhaseOutTime = Option(4.minutes)).validate() shouldBe
+      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be lower than keyPhaseOutTime!"))
   }
 }

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfigTest.scala
@@ -52,22 +52,22 @@ class InMemoryKeyConfigTest extends AnyFlatSpec with Matchers {
   }
 
   it should "fail on non-negative keyRotationTime" in {
-    inMemoryKeyConfig.copy(keyRotationTime = Option(5.milliseconds), keyPhaseOutTime = None).validate() shouldBe
+    inMemoryKeyConfig.copy(keyRotationTime = Option(5.milliseconds), keyPhaseOutTime = None, keyLayOverTime = None).validate() shouldBe
       ConfigValidationError(ConfigValidationException(s"keyRotationTime must be at least ${KeyConfig.minKeyRotationTime}"))
   }
 
   it should "fail on non-negative keyPhaseOutTime" in {
-    inMemoryKeyConfig.copy(keyPhaseOutTime = Option(5.milliseconds)).validate() shouldBe
+    inMemoryKeyConfig.copy(keyPhaseOutTime = Option(5.milliseconds), keyLayOverTime = None).validate() shouldBe
       ConfigValidationError(ConfigValidationException(s"keyPhaseOutTime must be at least ${KeyConfig.minKeyPhaseOutTime}"))
   }
 
   it should "fail on keyPhaseOutTime being configured without keyRotationTime" in {
-    inMemoryKeyConfig.copy(keyRotationTime = None).validate() shouldBe
+    inMemoryKeyConfig.copy(keyRotationTime = None, keyLayOverTime = None).validate() shouldBe
       ConfigValidationError(ConfigValidationException(s"keyPhaseOutTime can only be enable if keyRotationTime is enable!"))
   }
 
   it should "fail on keyPhaseOutTime being larger than keyRotationTime" in {
-    inMemoryKeyConfig.copy(keyRotationTime = Option(10.minutes)).validate() shouldBe
+    inMemoryKeyConfig.copy(keyRotationTime = Option(10.minutes), keyLayOverTime = None).validate() shouldBe
       ConfigValidationError(ConfigValidationException(s"keyPhaseOutTime must be lower than keyRotationTime!"))
   }
 

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/jwt/InMemoryKeyConfigTest.scala
@@ -66,11 +66,6 @@ class InMemoryKeyConfigTest extends AnyFlatSpec with Matchers {
       ConfigValidationError(ConfigValidationException(s"keyPhaseOutTime can only be enable if keyRotationTime is enable!"))
   }
 
-  it should "fail on keyPhaseOutTime being larger than keyRotationTime" in {
-    inMemoryKeyConfig.copy(keyRotationTime = Option(10.minutes), keyLayOverTime = None).validate() shouldBe
-      ConfigValidationError(ConfigValidationException(s"keyPhaseOutTime must be lower than keyRotationTime!"))
-  }
-
   it should "fail on non-negative keyLayOverTime" in {
     inMemoryKeyConfig.copy(keyLayOverTime = Option(5.milliseconds)).validate() shouldBe
       ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be at least ${KeyConfig.minKeyLayOverTime}"))
@@ -81,13 +76,9 @@ class InMemoryKeyConfigTest extends AnyFlatSpec with Matchers {
       ConfigValidationError(ConfigValidationException(s"keyLayOverTime can only be enable if keyRotationTime is enable!"))
   }
 
-  it should "fail on keyLayOverTime being larger than keyRotationTime" in {
-    inMemoryKeyConfig.copy(keyRotationTime = Option(4.minutes), keyPhaseOutTime = None).validate() shouldBe
-      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be lower than keyRotationTime!"))
+  it should "fail on keyLayOverTime + keyPhaseOutTime being larger than keyRotationTime" in {
+    inMemoryKeyConfig.copy(keyRotationTime = Option(10.minutes)).validate() shouldBe
+      ConfigValidationError(ConfigValidationException(s"keyLayOverTime + keyPhaseOutTime must be lower than keyRotationTime!"))
   }
 
-  it should "fail on keyLayOverTime being larger than keyPhaseOutTime" in {
-    inMemoryKeyConfig.copy(keyPhaseOutTime = Option(4.minutes)).validate() shouldBe
-      ConfigValidationError(ConfigValidationException(s"keyLayOverTime must be lower than keyPhaseOutTime!"))
-  }
 }

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
@@ -37,7 +37,9 @@ class ConfigProviderTest extends AnyFlatSpec with Matchers  {
     keyConfig.algName shouldBe "RS256"
     keyConfig.accessExpTime shouldBe FiniteDuration(15, TimeUnit.MINUTES)
     keyConfig.refreshExpTime shouldBe FiniteDuration(10, TimeUnit.HOURS)
-    keyConfig.keyRotationTime.get shouldBe FiniteDuration(5, TimeUnit.SECONDS)
+    keyConfig.keyRotationTime.get shouldBe FiniteDuration(20, TimeUnit.SECONDS)
+    keyConfig.keyPhaseOutTime.get shouldBe FiniteDuration(10, TimeUnit.SECONDS)
+    keyConfig.keyLayOverTime.get shouldBe FiniteDuration(5, TimeUnit.SECONDS)
   }
 
   "The ldapConfig properties" should "Match" in {

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
@@ -37,9 +37,9 @@ class ConfigProviderTest extends AnyFlatSpec with Matchers  {
     keyConfig.algName shouldBe "RS256"
     keyConfig.accessExpTime shouldBe FiniteDuration(15, TimeUnit.MINUTES)
     keyConfig.refreshExpTime shouldBe FiniteDuration(10, TimeUnit.HOURS)
-    keyConfig.keyRotationTime.get shouldBe FiniteDuration(20, TimeUnit.SECONDS)
-    keyConfig.keyPhaseOutTime.get shouldBe FiniteDuration(10, TimeUnit.SECONDS)
-    keyConfig.keyLayOverTime.get shouldBe FiniteDuration(5, TimeUnit.SECONDS)
+    keyConfig.keyRotationTime.get shouldBe FiniteDuration(10, TimeUnit.SECONDS)
+    keyConfig.keyLayOverTime.get shouldBe FiniteDuration(3, TimeUnit.SECONDS)
+    keyConfig.keyPhaseOutTime.get shouldBe FiniteDuration(3, TimeUnit.SECONDS)
   }
 
   "The ldapConfig properties" should "Match" in {

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/jwt/JWTServiceTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/jwt/JWTServiceTest.scala
@@ -197,7 +197,7 @@ class JWTServiceTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
   }
 
   it should "fail with a unreadable tokens" in {
-    an[MalformedJwtException] should be thrownBy {
+    an[JwtException] should be thrownBy {
       jwtService.refreshTokens(AccessToken("abc.def.ghi"), RefreshToken("123.456.789"))
     }
   }

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/jwt/JWTServiceTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/jwt/JWTServiceTest.scala
@@ -280,11 +280,11 @@ class JWTServiceTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
 
   behavior of "keyRotation"
 
-  it should "rotate public and private keys after 25 seconds" in {
+  it should "rotate public and private keys after 14 seconds" in {
     val initToken = jwtService.generateAccessToken(userWithoutGroups)
     val initPublicKey = jwtService.publicKeys
 
-    Thread.sleep(26000)
+    Thread.sleep(14000)
     val refreshedToken = jwtService.generateAccessToken(userWithoutGroups)
 
     assert(parseJWT(initToken).isFailure)
@@ -294,11 +294,11 @@ class JWTServiceTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
     assert(initPublicKey._1 == jwtService.publicKeys._2.orNull)
   }
 
-  it should "phase out older keys after 30 seconds" in {
+  it should "phase out older keys after 17 seconds" in {
     val initToken = jwtService.generateAccessToken(userWithoutGroups)
     val initPublicKey = jwtService.publicKeys
 
-    Thread.sleep(26000)
+    Thread.sleep(14000)
     val refreshedToken = jwtService.generateAccessToken(userWithoutGroups)
 
     assert(parseJWT(initToken).isFailure)
@@ -307,22 +307,22 @@ class JWTServiceTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
     assert(initPublicKey._1 != jwtService.publicKeys._1)
     assert(initPublicKey._1 == jwtService.publicKeys._2.orNull)
 
-    Thread.sleep(6000)
+    Thread.sleep(3000)
     assert(jwtService.publicKeys._2.isEmpty)
   }
 
-  it should "lay over keys after 25 seconds" in {
+  it should "lay over keys after 15 seconds" in {
     val initToken = jwtService.generateAccessToken(userWithoutGroups)
     val initPublicKey = jwtService.publicKeys
 
-    Thread.sleep(21000)
+    Thread.sleep(11000)
 
     assert(parseJWT(initToken).isSuccess)
     assert(initPublicKey != jwtService.publicKeys)
     assert(initPublicKey._1 == jwtService.publicKeys._1)
     assert(initPublicKey._1 != jwtService.publicKeys._2.orNull)
 
-    Thread.sleep(6000)
+    Thread.sleep(4000)
     val refreshedToken = jwtService.generateAccessToken(userWithoutGroups)
 
     assert(parseJWT(initToken).isFailure)

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/jwt/JWTServiceTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/jwt/JWTServiceTest.scala
@@ -280,11 +280,11 @@ class JWTServiceTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
 
   behavior of "keyRotation"
 
-  it should "rotate an public and private keys after 5 seconds" in {
+  it should "rotate public and private keys after 25 seconds" in {
     val initToken = jwtService.generateAccessToken(userWithoutGroups)
     val initPublicKey = jwtService.publicKeys
 
-    Thread.sleep(6 * 1000)
+    Thread.sleep(26000)
     val refreshedToken = jwtService.generateAccessToken(userWithoutGroups)
 
     assert(parseJWT(initToken).isFailure)
@@ -294,11 +294,11 @@ class JWTServiceTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
     assert(initPublicKey._1 == jwtService.publicKeys._2.orNull)
   }
 
-  it should "phase out older keys after 8 seconds" in {
+  it should "phase out older keys after 30 seconds" in {
     val initToken = jwtService.generateAccessToken(userWithoutGroups)
     val initPublicKey = jwtService.publicKeys
 
-    Thread.sleep(6 * 1000)
+    Thread.sleep(26000)
     val refreshedToken = jwtService.generateAccessToken(userWithoutGroups)
 
     assert(parseJWT(initToken).isFailure)
@@ -307,7 +307,28 @@ class JWTServiceTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
     assert(initPublicKey._1 != jwtService.publicKeys._1)
     assert(initPublicKey._1 == jwtService.publicKeys._2.orNull)
 
-    Thread.sleep(3 * 1000)
+    Thread.sleep(6000)
     assert(jwtService.publicKeys._2.isEmpty)
+  }
+
+  it should "lay over keys after 25 seconds" in {
+    val initToken = jwtService.generateAccessToken(userWithoutGroups)
+    val initPublicKey = jwtService.publicKeys
+
+    Thread.sleep(21000)
+
+    assert(parseJWT(initToken).isSuccess)
+    assert(initPublicKey != jwtService.publicKeys)
+    assert(initPublicKey._1 == jwtService.publicKeys._1)
+    assert(initPublicKey._1 != jwtService.publicKeys._2.orNull)
+
+    Thread.sleep(6000)
+    val refreshedToken = jwtService.generateAccessToken(userWithoutGroups)
+
+    assert(parseJWT(initToken).isFailure)
+    assert(parseJWT(refreshedToken).isSuccess)
+    assert(initPublicKey != jwtService.publicKeys)
+    assert(initPublicKey._1 != jwtService.publicKeys._1)
+    assert(initPublicKey._1 == jwtService.publicKeys._2.orNull)
   }
 }

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/jwt/JWTServiceTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/jwt/JWTServiceTest.scala
@@ -205,7 +205,7 @@ class JWTServiceTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
   def customTimedJwtService(accessExpTime: FiniteDuration, refreshExpTime: FiniteDuration): JWTService = {
     val configP = new JwtConfigProvider {
       override def getJwtKeyConfig: KeyConfig = InMemoryKeyConfig(
-        "RS256", accessExpTime, refreshExpTime, None, None
+        "RS256", accessExpTime, refreshExpTime, None, None, None
       )
     }
 


### PR DESCRIPTION
Release Notes:
- Added new Optional Config setting that allows for a layover period before signing new JWT's with the new keys
- Fixed RefreshToken to use both available public keys

closes #117 