### PR TITLE
#119 Introduce retries to ad ldap requests

### DIFF
--- a/api/src/main/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfig.scala
@@ -35,7 +35,7 @@ case class ActiveDirectoryLDAPConfig(domain: String,
                                      order: Int,
                                      serviceAccount: ServiceAccountConfig,
                                      enableKerberos: Option[KerberosConfig],
-                                     LdapRetry: Option[LdapRetryConfig],
+                                     ldapRetry: Option[LdapRetryConfig],
                                      attributes: Option[Map[String, String]])
   extends ConfigValidatable with ConfigOrdering
 {
@@ -70,7 +70,7 @@ case class ActiveDirectoryLDAPConfig(domain: String,
         case Some(x) => x.validate()
         case None => ConfigValidationSuccess
       }
-      val retryResults = LdapRetry match {
+      val retryResults = ldapRetry match {
         case Some(x) => x.validate()
         case None => ConfigValidationSuccess
       }
@@ -83,12 +83,14 @@ case class ActiveDirectoryLDAPConfig(domain: String,
 case class LdapRetryConfig(attempts: Int, delayMs: Int) extends ConfigValidatable {
   override def validate(): ConfigValidationResult = {
     val results = Seq(
-      Option(attempts)
-        .map(_ => ConfigValidationSuccess)
-        .getOrElse(ConfigValidationError(ConfigValidationException("attempts is empty"))),
-      Option(delayMs)
-        .map(_ => ConfigValidationSuccess)
-        .getOrElse(ConfigValidationError(ConfigValidationException("delayMs is empty")))
+      attempts match {
+        case x if x >= 1 => ConfigValidationSuccess
+        case _ => ConfigValidationError(ConfigValidationException("attempts is less than 1"))
+      },
+      delayMs match {
+        case x if x >= 10 => ConfigValidationSuccess
+        case _ => ConfigValidationError(ConfigValidationException("delayMs is less than 10ms"))
+      }
     )
     results.foldLeft[ConfigValidationResult](ConfigValidationSuccess)(ConfigValidationResult.merge)
   }

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
@@ -85,7 +85,7 @@ class ActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfi
     def attempt(n: Int): Future[Authentication] = Future {
       Try(baseImplementation.authenticate(authentication)) match {
         case Success(auth) => auth
-        case Failure(ex) if isRetryableException(ex) && n < attempts =>
+        case Failure(ex) if isRetryableException(ex) && n <= attempts =>
           logger.error(s"AD authentication failed on attempt $n: ${ex.getMessage}. Retrying in ${delayMs * n}ms...")
           Thread.sleep(delayMs * n)
           Await.result(attempt(n + 1), Duration.Inf)

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
@@ -92,8 +92,8 @@ class ActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfi
     def attempt(n: Int): Future[Authentication] = Future {
       Try(baseImplementation.authenticate(authentication)) match {
         case Success(auth) => auth
-        case Failure(ex) if isRetryableException(ex) && n < attempts =>
-          logger.error(s"AD authentication failed on attempt $n: ${ex.getMessage}. Retrying in ${delayMs}ms...")
+        case Failure(ex) if isRetryableException(ex) && n <= attempts =>
+          logger.error(s"AD authentication failed on attempt $n: ${ex.getMessage}. Retrying in ${delayMs * n}ms...")
           Thread.sleep(delayMs * n)
           Await.result(attempt(n + 1), Duration.Inf)
         case Failure(ex: BadCredentialsException) =>

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
@@ -55,7 +55,7 @@ class ActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfi
     val username = authentication.getName
     logger.info(s"Login of user $username via LDAP")
 
-    val fromBase = config.LdapRetry
+    val fromBase = config.ldapRetry
       .fold(singleAttemptAuth(authentication))(x =>
         retryAuthAsync(x.attempts, x.delayMs, authentication))
 

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepository.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepository.scala
@@ -106,7 +106,7 @@ class LdapUserRepository(activeDirectoryLDAPConfig: ActiveDirectoryLDAPConfig)
     def attempt(n: Int): Future[List[User]] = Future {
       Try(contextSearch(username)) match {
         case Success(searchResults) => searchResults
-        case Failure(ex) if n < attempts =>
+        case Failure(ex) if n <= attempts =>
           logger.error(s"AD authentication failed on attempt $n: ${ex.getMessage}. Retrying in ${delayMs * n}ms...")
           Thread.sleep(delayMs * n)
           Await.result(attempt(n + 1), Duration.Inf)

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepository.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepository.scala
@@ -112,8 +112,8 @@ class LdapUserRepository(activeDirectoryLDAPConfig: ActiveDirectoryLDAPConfig)
     def attempt(n: Int): Future[List[User]] = Future {
       Try(contextSearch(username)) match {
         case Success(searchResults) => searchResults
-        case Failure(ex) if n < attempts =>
-          logger.error(s"AD authentication failed on attempt $n: ${ex.getMessage}. Retrying in ${delayMs}ms...")
+        case Failure(ex) if n <= attempts =>
+          logger.error(s"AD authentication failed on attempt $n: ${ex.getMessage}. Retrying in ${delayMs * n}ms...")
           Thread.sleep(delayMs * n)
           Await.result(attempt(n + 1), Duration.Inf)
         case Failure(ex) =>

--- a/api/src/main/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepository.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepository.scala
@@ -35,7 +35,7 @@ class LdapUserRepository(activeDirectoryLDAPConfig: ActiveDirectoryLDAPConfig)
 
   private val logger = LoggerFactory.getLogger(classOf[LdapUserRepository])
   private val serviceAccount = activeDirectoryLDAPConfig.serviceAccount
-  private val retryConfig = activeDirectoryLDAPConfig.LdapRetry
+  private val retryConfig = activeDirectoryLDAPConfig.ldapRetry
   private val context = getDirContext(serviceAccount.username, serviceAccount.password)
 
   def searchForUser(username: String): Option[User] = {

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -23,6 +23,9 @@ loginsvc:
             in-config-account:
               username: "svc-ldap"
               password: "password"
+          ldap-retry:
+            attempts: 1
+            delay-ms: 10
           attributes:
             mail: "email"
             displayname: "displayname"

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -14,7 +14,7 @@ loginsvc:
     auth:
       provider:
         ldap:
-          order: 2
+          order: 0
           domain: "some.domain.com"
           url: "ldaps://some.domain.com:636/"
           search-filter: "(samaccountname={1})"

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -14,7 +14,7 @@ loginsvc:
     auth:
       provider:
         ldap:
-          order: 0
+          order: 2
           domain: "some.domain.com"
           url: "ldaps://some.domain.com:636/"
           search-filter: "(samaccountname={1})"

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfigTest.scala
@@ -28,7 +28,7 @@ class ActiveDirectoryLDAPConfigTest extends AnyFlatSpec with Matchers {
     "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
     Option(integratedCfg),
     None)
-  private val ldapCfg = ActiveDirectoryLDAPConfig("some.domain.com", "ldaps://some.domain.com:636/","SomeAccount", 1, serviceAccountCfg, None, None)
+  private val ldapCfg = ActiveDirectoryLDAPConfig("some.domain.com", "ldaps://some.domain.com:636/","SomeAccount", 1, serviceAccountCfg,None, None, None)
 
   "ActiveDirectoryLDAPConfig" should "validate expected filled content" in {
     ldapCfg.validate() shouldBe ConfigValidationSuccess
@@ -46,6 +46,6 @@ class ActiveDirectoryLDAPConfigTest extends AnyFlatSpec with Matchers {
   }
 
   it should "pass validation if disabled despite missing values" in {
-    ActiveDirectoryLDAPConfig(null, null, null, 0, null, None, None).validate() shouldBe ConfigValidationSuccess
+    ActiveDirectoryLDAPConfig(null, null, null, 0, null, None, None, None).validate() shouldBe ConfigValidationSuccess
   }
 }

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfigTest.scala
@@ -45,6 +45,14 @@ class ActiveDirectoryLDAPConfigTest extends AnyFlatSpec with Matchers {
       ConfigValidationError(ConfigValidationException("searchFilter is empty"))
   }
 
+  it should "fail on retryLdap missing parameters" in {
+    ldapCfg.copy(ldapRetry = Some(LdapRetryConfig(1, 0))).validate() shouldBe
+      ConfigValidationError(ConfigValidationException("delayMs is less than 10ms"))
+
+    ldapCfg.copy(ldapRetry = Some(LdapRetryConfig(0, 10))).validate() shouldBe
+      ConfigValidationError(ConfigValidationException("attempts is less than 1"))
+  }
+
   it should "pass validation if disabled despite missing values" in {
     ActiveDirectoryLDAPConfig(null, null, null, 0, null, None, None, None).validate() shouldBe ConfigValidationSuccess
   }

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
@@ -18,13 +18,12 @@ package za.co.absa.loginsvc.rest.config.provider
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import za.co.absa.loginsvc.rest.config.auth.{ActiveDirectoryLDAPConfig, UsersConfig}
+import za.co.absa.loginsvc.rest.config.auth.{ActiveDirectoryLDAPConfig, LdapRetryConfig, UsersConfig}
 import za.co.absa.loginsvc.rest.config.BaseConfig
 import za.co.absa.loginsvc.rest.config.jwt.KeyConfig
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
-
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
@@ -51,6 +50,7 @@ class ConfigProviderTest extends AnyFlatSpec with Matchers  {
     activeDirectoryLDAPConfig.serviceAccount.username shouldBe "CN=svc-ldap,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com"
     activeDirectoryLDAPConfig.serviceAccount.password shouldBe "password"
     activeDirectoryLDAPConfig.enableKerberos shouldBe None
+    activeDirectoryLDAPConfig.ldapRetry shouldBe Some(LdapRetryConfig(1, 10))
     activeDirectoryLDAPConfig.attributes shouldBe Some(Map("mail" -> "email", "displayname" -> "displayname"))
   }
 

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
@@ -46,7 +46,7 @@ class ConfigProviderTest extends AnyFlatSpec with Matchers  {
     activeDirectoryLDAPConfig.url shouldBe "ldaps://some.domain.com:636/"
     activeDirectoryLDAPConfig.domain shouldBe "some.domain.com"
     activeDirectoryLDAPConfig.searchFilter shouldBe "(samaccountname={1})"
-    activeDirectoryLDAPConfig.order shouldBe 2
+    activeDirectoryLDAPConfig.order shouldBe 0
     activeDirectoryLDAPConfig.serviceAccount.username shouldBe "CN=svc-ldap,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com"
     activeDirectoryLDAPConfig.serviceAccount.password shouldBe "password"
     activeDirectoryLDAPConfig.enableKerberos shouldBe None

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/provider/ConfigProviderTest.scala
@@ -46,7 +46,7 @@ class ConfigProviderTest extends AnyFlatSpec with Matchers  {
     activeDirectoryLDAPConfig.url shouldBe "ldaps://some.domain.com:636/"
     activeDirectoryLDAPConfig.domain shouldBe "some.domain.com"
     activeDirectoryLDAPConfig.searchFilter shouldBe "(samaccountname={1})"
-    activeDirectoryLDAPConfig.order shouldBe 0
+    activeDirectoryLDAPConfig.order shouldBe 2
     activeDirectoryLDAPConfig.serviceAccount.username shouldBe "CN=svc-ldap,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com"
     activeDirectoryLDAPConfig.serviceAccount.password shouldBe "password"
     activeDirectoryLDAPConfig.enableKerberos shouldBe None

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProviderTest.scala
@@ -19,7 +19,6 @@ package za.co.absa.loginsvc.rest.provider.ad.ldap
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.Answer
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.springframework.security.authentication.{
@@ -66,7 +65,7 @@ class ActiveDirectoryLDAPAuthenticationProviderTest extends AnyFlatSpec with Mat
         new User("user", "password", Collections.singleton(
           new SimpleGrantedAuthority("ROLE_USER"))), Map("testAtt" -> None))
       val auth = new UsernamePasswordAuthenticationToken(userDetails, "password", userDetails.getAuthorities)
-      config.ldapRetry.fold(auth)({ x =>
+      config.ldapRetry.fold(auth)({ _ =>
         if (counter < 4) {
           counter += 1
           throw new RuntimeException("TestException")

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProviderTest.scala
@@ -43,7 +43,7 @@ class ActiveDirectoryLDAPAuthenticationProviderTest extends AnyFlatSpec with Mat
     "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
     Option(integratedCfg),
     None)
-  private val ldapCfg = ActiveDirectoryLDAPConfig(
+  private val ldapCfgNoRetries = ActiveDirectoryLDAPConfig(
     "some.domain.com",
     "ldaps://some.domain.com:636/",
     "SomeAccount",
@@ -56,17 +56,20 @@ class ActiveDirectoryLDAPAuthenticationProviderTest extends AnyFlatSpec with Mat
   private val principal = CustomUser("user", List("ROLE_USER"), Map("testAtt" -> None))
   private val mockAuthentication = mock(classOf[Authentication])
 
-  private class TestActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfig, mockAuthenticationProvider: AuthenticationProvider)
+  private class TestActiveDirectoryLDAPAuthenticationProviderEventuallySucceeding(config: ActiveDirectoryLDAPConfig, mockAuthenticationProvider: AuthenticationProvider)
     extends ActiveDirectoryLDAPAuthenticationProvider(config) {
-    private var counter: Int = 1
+    private var counter: Int = 0
     override private[ldap] def createAuthenticationProvider = mockAuthenticationProvider
     when(mockAuthenticationProvider.authenticate(any[Authentication])).thenAnswer((_: InvocationOnMock) => {
       val userDetails: UserDetails = UserDetailsWithExtras(
-        new User("user", "password", Collections.singleton(
-          new SimpleGrantedAuthority("ROLE_USER"))), Map("testAtt" -> None))
+        new User(
+          "user",
+          "password",
+          Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))),
+        Map("testAtt" -> None))
       val auth = new UsernamePasswordAuthenticationToken(userDetails, "password", userDetails.getAuthorities)
       config.ldapRetry.fold(auth)({ _ =>
-        if (counter < 4) {
+        if (counter < 3) {
           counter += 1
           throw new RuntimeException("TestException")
         }
@@ -78,7 +81,7 @@ class ActiveDirectoryLDAPAuthenticationProviderTest extends AnyFlatSpec with Mat
   "authenticate" should "only be called once when ldapRetry is None" in {
     val mockAuthenticationProvider = mock(classOf[AuthenticationProvider])
     val testActiveDirectoryLDAPAuthenticationProvider =
-      new TestActiveDirectoryLDAPAuthenticationProvider(ldapCfg, mockAuthenticationProvider)
+      new TestActiveDirectoryLDAPAuthenticationProviderEventuallySucceeding(ldapCfgNoRetries, mockAuthenticationProvider)
     val testUser = testActiveDirectoryLDAPAuthenticationProvider.authenticate(mockAuthentication)
 
     verify(mockAuthenticationProvider, times(1)).authenticate(mockAuthentication)
@@ -86,30 +89,30 @@ class ActiveDirectoryLDAPAuthenticationProviderTest extends AnyFlatSpec with Mat
   }
 
   "authenticate" should "be called 4 times before a successful attempt occurs" in {
-    val retryConfig = LdapRetryConfig(4, 100)
-    val ldapConfig = ldapCfg.copy(ldapRetry = Some(retryConfig))
+    val retryConfig = LdapRetryConfig(3, 100)
+    val ldapCfg = ldapCfgNoRetries.copy(ldapRetry = Some(retryConfig))
 
     val mockAuthenticationProvider = mock(classOf[AuthenticationProvider])
     val testActiveDirectoryLDAPAuthenticationProvider =
-      new TestActiveDirectoryLDAPAuthenticationProvider(ldapConfig, mockAuthenticationProvider)
+      new TestActiveDirectoryLDAPAuthenticationProviderEventuallySucceeding(ldapCfg, mockAuthenticationProvider)
     val testUser = testActiveDirectoryLDAPAuthenticationProvider.authenticate(mockAuthentication)
 
     verify(mockAuthenticationProvider, times(4)).authenticate(mockAuthentication)
     assert(testUser.getPrincipal == principal)
   }
 
-  "authenticate" should "be fail after 2 retries" in {
+  "authenticate" should "fail after 2 retries" in {
     val retryConfig = LdapRetryConfig(2, 100)
-    val ldapConfig = ldapCfg.copy(ldapRetry = Some(retryConfig))
+    val ldapCfg = ldapCfgNoRetries.copy(ldapRetry = Some(retryConfig))
 
     val mockAuthenticationProvider = mock(classOf[AuthenticationProvider])
     val testActiveDirectoryLDAPAuthenticationProvider =
-      new TestActiveDirectoryLDAPAuthenticationProvider(ldapConfig, mockAuthenticationProvider)
+      new TestActiveDirectoryLDAPAuthenticationProviderEventuallySucceeding(ldapCfg, mockAuthenticationProvider)
 
     assertThrows[RuntimeException] {
       testActiveDirectoryLDAPAuthenticationProvider.authenticate(mockAuthentication)
     }
 
-    verify(mockAuthenticationProvider, times(2)).authenticate(mockAuthentication)
+    verify(mockAuthenticationProvider, times(3)).authenticate(mockAuthentication)
   }
 }

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProviderTest.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.loginsvc.rest.provider.ad.ldap
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{mock, times, verify, when}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.springframework.security.authentication.{
+  AuthenticationProvider,
+  UsernamePasswordAuthenticationToken}
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.{User, UserDetails}
+import za.co.absa.loginsvc.model.{User => CustomUser}
+import za.co.absa.loginsvc.rest.config.auth.{
+  ActiveDirectoryLDAPConfig,
+  LdapRetryConfig,
+  LdapUserCredentialsConfig,
+  ServiceAccountConfig}
+
+import java.util.Collections
+
+class ActiveDirectoryLDAPAuthenticationProviderTest extends AnyFlatSpec with Matchers {
+
+  private val integratedCfg = LdapUserCredentialsConfig("svc-ldap", "password")
+  private val serviceAccountCfg = ServiceAccountConfig(
+    "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
+    Option(integratedCfg),
+    None)
+  private val ldapCfg = ActiveDirectoryLDAPConfig(
+    "some.domain.com",
+    "ldaps://some.domain.com:636/",
+    "SomeAccount",
+    1,
+    serviceAccountCfg,
+    None,
+    None,
+    None)
+
+  private val principal = CustomUser("user", List("ROLE_USER"), Map("testAtt" -> None))
+  private val mockAuthentication = mock(classOf[Authentication])
+
+  private class TestActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfig, mockAuthenticationProvider: AuthenticationProvider)
+    extends ActiveDirectoryLDAPAuthenticationProvider(config) {
+    private var counter: Int = 1
+    override private[ldap] def createAuthenticationProvider = mockAuthenticationProvider
+    when(mockAuthenticationProvider.authenticate(any[Authentication])).thenAnswer((_: InvocationOnMock) => {
+      val userDetails: UserDetails = UserDetailsWithExtras(
+        new User("user", "password", Collections.singleton(
+          new SimpleGrantedAuthority("ROLE_USER"))), Map("testAtt" -> None))
+      val auth = new UsernamePasswordAuthenticationToken(userDetails, "password", userDetails.getAuthorities)
+      config.ldapRetry.fold(auth)({ x =>
+        if (counter < 4) {
+          counter += 1
+          throw new RuntimeException("TestException")
+        }
+        else auth
+      })
+    })
+  }
+
+  "authenticate" should "only be called once when ldapRetry is None" in {
+    val mockAuthenticationProvider = mock(classOf[AuthenticationProvider])
+    val testActiveDirectoryLDAPAuthenticationProvider =
+      new TestActiveDirectoryLDAPAuthenticationProvider(ldapCfg, mockAuthenticationProvider)
+    val testUser = testActiveDirectoryLDAPAuthenticationProvider.authenticate(mockAuthentication)
+
+    verify(mockAuthenticationProvider, times(1)).authenticate(mockAuthentication)
+    assert(testUser.getPrincipal == principal)
+  }
+
+  "authenticate" should "be called 4 times before a successful attempt occurs" in {
+    val retryConfig = LdapRetryConfig(4, 100)
+    val ldapConfig = ldapCfg.copy(ldapRetry = Some(retryConfig))
+
+    val mockAuthenticationProvider = mock(classOf[AuthenticationProvider])
+    val testActiveDirectoryLDAPAuthenticationProvider =
+      new TestActiveDirectoryLDAPAuthenticationProvider(ldapConfig, mockAuthenticationProvider)
+    val testUser = testActiveDirectoryLDAPAuthenticationProvider.authenticate(mockAuthentication)
+
+    verify(mockAuthenticationProvider, times(4)).authenticate(mockAuthentication)
+    assert(testUser.getPrincipal == principal)
+  }
+
+  "authenticate" should "be fail after 2 retries" in {
+    val retryConfig = LdapRetryConfig(2, 100)
+    val ldapConfig = ldapCfg.copy(ldapRetry = Some(retryConfig))
+
+    val mockAuthenticationProvider = mock(classOf[AuthenticationProvider])
+    val testActiveDirectoryLDAPAuthenticationProvider =
+      new TestActiveDirectoryLDAPAuthenticationProvider(ldapConfig, mockAuthenticationProvider)
+
+    assertThrows[RuntimeException] {
+      testActiveDirectoryLDAPAuthenticationProvider.authenticate(mockAuthentication)
+    }
+
+    verify(mockAuthenticationProvider, times(2)).authenticate(mockAuthentication)
+  }
+}

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/search/DefaultUserRepositoriesTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/search/DefaultUserRepositoriesTest.scala
@@ -30,10 +30,10 @@ class DefaultUserRepositoriesTest extends AnyFlatSpec with BeforeAndAfterEach wi
   private val testConfig: ConfigProvider = new ConfigProvider("api/src/test/resources/application.yaml")
   private val emptyServiceAccount = ServiceAccountConfig("", Option(LdapUserCredentialsConfig("", "")), None)
 
-  private val enabledLdapTestConfig = Some(ActiveDirectoryLDAPConfig("", "", "", order = 2, emptyServiceAccount, None, None))
+  private val enabledLdapTestConfig = Some(ActiveDirectoryLDAPConfig("", "", "", order = 2, emptyServiceAccount, None, None, None))
   private val enabledUsersConfig = testConfig.getUsersConfig // has order = 1
 
-  private val disabledLdapTestConfig = Some(ActiveDirectoryLDAPConfig("", "", "", order = 0, emptyServiceAccount, None, None))
+  private val disabledLdapTestConfig = Some(ActiveDirectoryLDAPConfig("", "", "", order = 0, emptyServiceAccount, None, None, None))
   private val disabledUsersConfig = Some(UsersConfig(Array.empty[UserConfig], order = 0))
 
   private def createAuthConfigProviderUsing(optLdapConfig: Option[ActiveDirectoryLDAPConfig], optUsersConfig: Option[UsersConfig]): AuthConfigProvider = {

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepositoryTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepositoryTest.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.loginsvc.rest.service.search
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.loginsvc.model.User
+import za.co.absa.loginsvc.rest.config.auth.{ActiveDirectoryLDAPConfig, LdapRetryConfig, LdapUserCredentialsConfig, ServiceAccountConfig}
+
+class LdapUserRepositoryTest extends AnyFlatSpec with Matchers {
+
+  private val integratedCfg = LdapUserCredentialsConfig("svc-ldap", "password")
+  private val serviceAccountCfg = ServiceAccountConfig(
+    "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
+    Option(integratedCfg),
+    None)
+  private val ldapCfg = ActiveDirectoryLDAPConfig(
+    "some.domain.com",
+    "ldaps://some.domain.com:636/",
+    "SomeAccount",
+    1,
+    serviceAccountCfg,
+    None,
+    None,
+    None)
+
+  private val testUser: User = User("user",
+    Seq("group1", "group2"),
+    Map("testAtt" -> None))
+
+  private class TestLdapUserRepository(config: ActiveDirectoryLDAPConfig)
+    extends LdapUserRepository(config) {
+    var counter: Int = 1
+    override def contextSearch(username: String): List[User] = {
+      config.ldapRetry.fold(List(testUser))(_ => {
+        if(counter < 4) {
+          counter += 1
+          throw new RuntimeException("TestException")
+        }
+        else List(testUser)
+      })
+    }
+  }
+
+  "ContextSearch" should "only be called once when ldapRetry is None" in {
+    val testLdapUserRepository = new TestLdapUserRepository(ldapCfg)
+    val user = testLdapUserRepository.searchForUser(testUser.name)
+
+    assert(testLdapUserRepository.counter == 1)
+    assert(user.get == testUser)
+  }
+
+  "authenticate" should "be called 4 times before a successful attempt occurs" in {
+    val retryConfig = LdapRetryConfig(4, 100)
+    val ldapConfig = ldapCfg.copy(ldapRetry = Some(retryConfig))
+
+    val testLdapUserRepository = new TestLdapUserRepository(ldapConfig)
+    val user = testLdapUserRepository.searchForUser(testUser.name)
+
+    assert(testLdapUserRepository.counter == 4)
+    assert(user.get == testUser)
+  }
+
+  "authenticate" should "be fail after 2 retries" in {
+    val retryConfig = LdapRetryConfig(2, 100)
+    val ldapConfig = ldapCfg.copy(ldapRetry = Some(retryConfig))
+
+    val testLdapUserRepository = new TestLdapUserRepository(ldapConfig)
+
+    assertThrows[RuntimeException] {
+      testLdapUserRepository.searchForUser(testUser.name)
+    }
+    assert(testLdapUserRepository.counter == 3)
+  }
+}


### PR DESCRIPTION
Release Notes:
- Introduced Retry functionality on Ldap requests that are configurable.
- Retries will only occur when it's a connection or Ldap related error. Bad Credentials will cause an immediate failure and will not retry.

closes #119 