### PR TITLE
(#129) ls pwd rotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ or just exclude the properties from the config for that auth provider.
 Please ensure at least one auth method is enabled.
 
 For the service account used to search LDAP, the Service Account Name and password may be specified in the config file.
-For a more secure approach, the service account name and password may be specified in AWS Secrets Manager and the application will fetch them from there.
+For a more secure approach, the service account name and password may be specified in AWS Secrets Manager
+or in AWS Systems Manager Parameter Store and the application will fetch them from there.
 
 The config also allows the user to specify additional claims to be added to the JWT token. 
 These can be sourced from LDAP or specified directly in the config depending on the auth provider used.
@@ -139,6 +140,25 @@ Format of attributes list under LDAP in config is:
 ```
 
 `ldapFieldName` is the name of the field in the LDAP server and `claimName` is the name of the claim that will be added to the JWT token.
+
+In order to utilize AWS services in order to store your service account details, replace `in-config-account` with:
+```
+            aws-secrets-manager-account:
+              secret-name: "secret"
+              region: "region"
+              username-field-name: "username"
+              password-field-name: "password"
+```
+This will retrieve these details securely from AWS secrets manager.
+Alternatively:
+```
+            aws-systems-manager-account:
+              parameter: "/parameter/path"
+              decrypt-if-secure: true
+              username-field-name: "username"
+              password-field-name: "password"
+```
+This will retrieve these details securely from AWS systems manager parameter store.
 
 ### Enabling SPNEGO authentication with LDAP
 When LDAP authentication is used, there is the option of adding SPNEGO authentication via kerberos.

--- a/api/src/main/resources/example.application.yaml
+++ b/api/src/main/resources/example.application.yaml
@@ -77,6 +77,12 @@ loginsvc:
               #region: "region"
               #username-field-name: "username"
               #password-field-name: "password"
+          # As an Alternative to Secrets, you may use AWS Systems Manager
+          #aws-systems-manager-account
+            #parameter: "parameter path"
+            #decrypt-if-secure: true
+            #username-field-name: "username"
+            #password-field-name: "password"
           # Enables Kerberos Authentication to the Login-Service
           #enable-kerberos:
             #krb-file-location: "/etc/krb5.conf"

--- a/api/src/main/scala/za/co/absa/loginsvc/utils/AwsSsmUtils.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/utils/AwsSsmUtils.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.loginsvc.utils
+
+import software.amazon.awssdk.services.ssm.SsmClient
+import software.amazon.awssdk.services.ssm.model._
+import org.slf4j.LoggerFactory
+
+object AwsSsmUtils extends SsmUtils {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def getParameter(paramName: String, decryptIfSecure: Boolean): Option[String] = {
+    val ssm: SsmClient = SsmClient.builder().build()
+    val request = GetParameterRequest.builder()
+      .name(paramName)
+      .withDecryption(decryptIfSecure)
+      .build()
+    try {
+      logger.info(s"Attempting to fetch $paramName from AWS Ssm")
+      val response = ssm.getParameter(request)
+      logger.info(s"$paramName retrieved.")
+      Some(response.parameter().value())
+    }
+    catch {
+      case e: Throwable =>
+        logger.warn(s"Error occurred retrieving $paramName from AWS Ssm", e)
+        None
+    }
+  }
+}
+
+trait SsmUtils {
+  def getParameter(paramName: String, decryptIfSecure: Boolean = true): Option[String]
+}

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/auth/ActiveDirectoryLDAPConfigTest.scala
@@ -27,6 +27,7 @@ class ActiveDirectoryLDAPConfigTest extends AnyFlatSpec with Matchers {
   private val serviceAccountCfg = ServiceAccountConfig(
     "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
     Option(integratedCfg),
+    None,
     None)
   private val ldapCfg = ActiveDirectoryLDAPConfig("some.domain.com", "ldaps://some.domain.com:636/","SomeAccount", 1, serviceAccountCfg,None, None, None)
 

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/config/auth/ServiceAccountConfigTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/config/auth/ServiceAccountConfigTest.scala
@@ -29,6 +29,7 @@ class ServiceAccountConfigTest extends AnyFlatSpec with Matchers {
   private val serviceAccountCfg = ServiceAccountConfig(
     "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
     Option(integratedCfg),
+    None,
     None)
 
   "ServiceAccountConfig" should "have validated and gotten the correct username and password" in {
@@ -42,19 +43,21 @@ class ServiceAccountConfigTest extends AnyFlatSpec with Matchers {
       ServiceAccountConfig(
         "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
         None,
+        None,
         None)
     }
-    bothNoneException.getMessage should be ("Neither integratedLdapUserConfig nor awsSecretsLdapUserConfig exists. Exactly one of them should be present.")
+    bothNoneException.getMessage should be ("None of the options are defined. Exactly one of them should be present.")
 
     val bothSomeException = intercept[ConfigValidationException]
       {
         ServiceAccountConfig(
           "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
           Some(integratedCfg),
-          Some(cloudCfg))
+          Some(cloudCfg),
+          None)
       }
 
-    bothSomeException.getMessage should be ("Both inConfigAccount and awsSecretsLdapUserConfig exist. Please choose only one.")
+    bothSomeException.getMessage should be ("More than one option is defined. Please choose only one.")
   }
 
   "LdapUserCredentialsConfig" should "return the correct validation results" in {

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProviderTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProviderTest.scala
@@ -42,6 +42,7 @@ class ActiveDirectoryLDAPAuthenticationProviderTest extends AnyFlatSpec with Mat
   private val serviceAccountCfg = ServiceAccountConfig(
     "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
     Option(integratedCfg),
+    None,
     None)
   private val ldapCfgNoRetries = ActiveDirectoryLDAPConfig(
     "some.domain.com",

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/actuator/GitInfoServiceTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/actuator/GitInfoServiceTest.scala
@@ -22,7 +22,6 @@ import org.springframework.boot.actuate.info.Info.Builder
 import org.springframework.boot.test.context.SpringBootTest
 import org.mockito.Mockito._
 import za.co.absa.loginsvc.rest.config.actuator.GitPropertiesGenerator
-import za.co.absa.loginsvc.rest.service.actuator.GitInfoService
 
 @SpringBootTest
 class GitInfoServiceTest extends AnyFlatSpec with Matchers {

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/actuator/LdapHealthServiceTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/actuator/LdapHealthServiceTest.scala
@@ -22,7 +22,6 @@ import org.springframework.boot.actuate.health.Health
 import org.springframework.boot.test.context.SpringBootTest
 import za.co.absa.loginsvc.rest.config.auth.{ActiveDirectoryLDAPConfig, LdapUserCredentialsConfig, ServiceAccountConfig, UsersConfig}
 import za.co.absa.loginsvc.rest.config.provider.AuthConfigProvider
-import za.co.absa.loginsvc.rest.service.actuator.LdapHealthService
 
 import javax.naming.CommunicationException
 import javax.naming.directory.DirContext
@@ -34,6 +33,7 @@ class LdapHealthServiceTest extends AnyFlatSpec with Matchers {
   private val serviceAccountCfg = ServiceAccountConfig(
     "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
     Option(integratedCfg),
+    None,
     None)
   private val ldapCfgZeroOrder = ActiveDirectoryLDAPConfig(
     "some.domain.com",

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/search/DefaultUserRepositoriesTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/search/DefaultUserRepositoriesTest.scala
@@ -28,7 +28,7 @@ import za.co.absa.loginsvc.rest.config.validation.ConfigValidationException
 class DefaultUserRepositoriesTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers with MockFactory {
 
   private val testConfig: ConfigProvider = new ConfigProvider("api/src/test/resources/application.yaml")
-  private val emptyServiceAccount = ServiceAccountConfig("", Option(LdapUserCredentialsConfig("", "")), None)
+  private val emptyServiceAccount = ServiceAccountConfig("", Option(LdapUserCredentialsConfig("", "")), None, None)
 
   private val enabledLdapTestConfig = Some(ActiveDirectoryLDAPConfig("", "", "", order = 2, emptyServiceAccount, None, None, None))
   private val enabledUsersConfig = testConfig.getUsersConfig // has order = 1

--- a/api/src/test/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepositoryTest.scala
+++ b/api/src/test/scala/za/co/absa/loginsvc/rest/service/search/LdapUserRepositoryTest.scala
@@ -27,6 +27,7 @@ class LdapUserRepositoryTest extends AnyFlatSpec with Matchers {
   private val serviceAccountCfg = ServiceAccountConfig(
     "CN=%s,OU=Users,OU=Accounts,DC=domain,DC=subdomain,DC=com",
     Option(integratedCfg),
+    None,
     None)
   private val ldapCfgNoRetries = ActiveDirectoryLDAPConfig(
     "some.domain.com",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,6 +64,7 @@ object Dependencies {
   lazy val awsSecrets = "software.amazon.awssdk" % "secretsmanager" % "2.20.68"
   lazy val awsSts = "software.amazon.awssdk" % "sts" % "2.20.69"
   lazy val awsSoo = "software.amazon.awssdk" % "sso" % "2.20.69"
+  lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.29.25"
 
   lazy val servletApi = "javax.servlet" % "javax.servlet-api" % "3.0.1" % Provided
 
@@ -104,6 +105,7 @@ object Dependencies {
     awsSecrets,
     awsSts,
     awsSoo,
+    awsSsm,
 
     springDoc,
 


### PR DESCRIPTION
Release Notes:
- Added Option for AWS SSM Paramter Store as alternative to AWS Secrets manager for storing credentials
- Updated Tests to support the new addition
- Updated ReadMe to indicate how to implement.