### PR TITLE
release draft typo fix

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -67,7 +67,7 @@ jobs:
           from-tag-name: ${{ github.event.inputs.from-tag-name }}
           chapters: |
             - { title: No entry 🚫, label: duplicate }
-            - { title: No entry 🚫, label: no RN },
+            - { title: No entry 🚫, label: no RN }
             - { title: Breaking Changes 💥, label: breaking-change }
             - { title: New Features 🎉, label: enhancement }
             - { title: New Features 🎉, label: feature }


### PR DESCRIPTION
Small typo preventing the Draft release WF to run

## Evidence of this fix working:
https://github.com/AbsaOSS/login-service/actions/runs/18345028987

Release notes:
 - Create draft WF fixed
