### PR TITLE
#156 fixing: generic 401 bears no error body content

### DIFF
--- a/api/src/main/scala/za/co/absa/loginsvc/rest/SecurityConfig.scala
+++ b/api/src/main/scala/za/co/absa/loginsvc/rest/SecurityConfig.scala
@@ -93,6 +93,8 @@ class SecurityConfig @Autowired()(authConfigsProvider: AuthConfigProvider, authM
 
         case _ =>
           response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+          response.setContentType("application/json");
+          response.getWriter.write(s"""{"error": "User login error"}""");
       }
     }
 


### PR DESCRIPTION
Fixes #156.

In the particular case, the Error code was sent, but there was no body, now there is a json error body as per Swagger doc.

Release notes:
 - Bugfix: 401 Responses were missing body with error description despite the API doc stating so.